### PR TITLE
Consider the terminating NULL character of the extended brand string instead of always going for the 48 characters.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2788,7 +2788,13 @@ impl ExtendedFunctionInfo {
         if self.leaf_is_supported(EAX_EXTENDED_BRAND_STRING) {
             Some(unsafe {
                 let brand_string_start = transmute::<&CpuIdResult, *const u8>(&self.data[2]);
-                let slice = slice::from_raw_parts(brand_string_start, 3 * 4 * 4);
+                let mut slice = slice::from_raw_parts(brand_string_start, 3 * 4 * 4);
+
+                match slice.iter().position(|&x| x == 0) {
+                    Some(index) => slice = slice::from_raw_parts(brand_string_start, index),
+                    None => (),
+                }
+
                 let byte_array: &'static [u8] = transmute(slice);
                 str::from_utf8_unchecked(byte_array)
             })


### PR DESCRIPTION
See Intel Vol. 2A, Table 3.13.
Fixes question mark characters in extended brand string (e.g. when using raw_cpuid under QEMU).