### PR TITLE
Rust assembly by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/gz/rust-cpuid"
 documentation = "http://gz.github.io/rust-cpuid/raw_cpuid/"
 
 readme = "README.md"
-keywords = ["cpuid", "x86", "amd64", "os", "libcore"]
+keywords = ["cpuid", "x86", "amd64", "IA-32", "i386", "os", "libcore"]
 license = "MIT"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "raw-cpuid"
 version = "3.1.0"
 authors = ["Gerd Zellweger <mail@gerdzellweger.com>"]
-build = "build.rs"
 
 description = "A library to parse the x86 CPUID instruction, written in rust with no external dependencies. The implementation closely resembles the Intel CPUID manual description. The library does only depend on libcore."
 homepage = "https://github.com/gz/rust-cpuid"
@@ -15,6 +14,3 @@ license = "MIT"
 
 [dependencies]
 bitflags = "0.7"
-
-[build-dependencies]
-gcc = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,0 @@
-extern crate gcc;
-
-fn main() {
-    gcc::Build::new()
-        .file("src/cpuid.c")
-        .compile("libcpuid.a");
-
-}

--- a/src/cpuid.c
+++ b/src/cpuid.c
@@ -1,7 +1,0 @@
-#include <stdint.h>
-
-void c_cpuid(uint32_t* a, uint32_t* b, uint32_t* c, uint32_t* d) {
-   asm volatile ("cpuid"
-      : "+a"(*a), "=b"(*b), "+c"(*c), "=d"(*d)
-   );
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+#![feature(asm)]
+
 #![crate_name = "raw_cpuid"]
 #![crate_type = "lib"]
 
@@ -10,8 +12,10 @@ extern crate bitflags;
 #[macro_use]
 extern crate std;
 
-extern "C" {
-    fn c_cpuid(a: *mut u32, b: *mut u32, c: *mut u32, d: *mut u32);
+unsafe fn c_cpuid(a: *mut u32, b: *mut u32, c: *mut u32, d: *mut u32) {
+    asm!("cpuid"
+         : "+{eax}"(*a), "={ebx}"(*b), "+{ecx}"(*c), "={edx}"(*d)
+         : : : "volatile")
 }
 
 use core::str;
@@ -103,13 +107,13 @@ macro_rules! check_flag {
         pub fn $fun(&self) -> bool {
             self.$flags.contains($flag)
         }
-    )
+        )
 }
 
 macro_rules! is_bit_set {
     ($field:expr, $bit:expr) => (
         $field & (1 << $bit) > 0
-    )
+        )
 }
 
 macro_rules! check_bit_fn {
@@ -118,7 +122,7 @@ macro_rules! check_bit_fn {
         pub fn $fun(&self) -> bool {
             is_bit_set!(self.$field, $bit)
         }
-    )
+        )
 }
 
 /// Main type used to query for information about the CPU we're running on.
@@ -445,59 +449,59 @@ impl CpuId {
         let mut ef = ExtendedFunctionInfo {
             max_eax_value: res.eax - EAX_EXTENDED_FUNCTION_INFO,
             data: [CpuIdResult {
-                       eax: res.eax,
-                       ebx: res.ebx,
-                       ecx: res.ecx,
-                       edx: res.edx,
-                   },
-                   CpuIdResult {
-                       eax: 0,
-                       ebx: 0,
-                       ecx: 0,
-                       edx: 0,
-                   },
-                   CpuIdResult {
-                       eax: 0,
-                       ebx: 0,
-                       ecx: 0,
-                       edx: 0,
-                   },
-                   CpuIdResult {
-                       eax: 0,
-                       ebx: 0,
-                       ecx: 0,
-                       edx: 0,
-                   },
-                   CpuIdResult {
-                       eax: 0,
-                       ebx: 0,
-                       ecx: 0,
-                       edx: 0,
-                   },
-                   CpuIdResult {
-                       eax: 0,
-                       ebx: 0,
-                       ecx: 0,
-                       edx: 0,
-                   },
-                   CpuIdResult {
-                       eax: 0,
-                       ebx: 0,
-                       ecx: 0,
-                       edx: 0,
-                   },
-                   CpuIdResult {
-                       eax: 0,
-                       ebx: 0,
-                       ecx: 0,
-                       edx: 0,
-                   },
-                   CpuIdResult {
-                       eax: 0,
-                       ebx: 0,
-                       ecx: 0,
-                       edx: 0,
-                   }],
+                eax: res.eax,
+                ebx: res.ebx,
+                ecx: res.ecx,
+                edx: res.edx,
+            },
+            CpuIdResult {
+                eax: 0,
+                ebx: 0,
+                ecx: 0,
+                edx: 0,
+            },
+            CpuIdResult {
+                eax: 0,
+                ebx: 0,
+                ecx: 0,
+                edx: 0,
+            },
+            CpuIdResult {
+                eax: 0,
+                ebx: 0,
+                ecx: 0,
+                edx: 0,
+            },
+            CpuIdResult {
+                eax: 0,
+                ebx: 0,
+                ecx: 0,
+                edx: 0,
+            },
+            CpuIdResult {
+                eax: 0,
+                ebx: 0,
+                ecx: 0,
+                edx: 0,
+            },
+            CpuIdResult {
+                eax: 0,
+                ebx: 0,
+                ecx: 0,
+                edx: 0,
+            },
+            CpuIdResult {
+                eax: 0,
+                ebx: 0,
+                ecx: 0,
+                edx: 0,
+            },
+            CpuIdResult {
+                eax: 0,
+                ebx: 0,
+                ecx: 0,
+                edx: 0,
+            }],
         };
 
         let max_eax_value = min(ef.max_eax_value + 1, ef.data.len() as u32);
@@ -616,553 +620,553 @@ impl fmt::Display for CacheInfo {
 
 /// This table is taken from Intel manual (Section CPUID instruction).
 pub const CACHE_INFO_TABLE: [CacheInfo; 107] =
-    [CacheInfo {
-         num: 0x00,
-         typ: CacheInfoType::GENERAL,
-         desc: "Null descriptor, this byte contains no information",
-     },
-     CacheInfo {
-         num: 0x01,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 4 KByte pages, 4-way set associative, 32 entries",
-     },
-     CacheInfo {
-         num: 0x02,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 4 MByte pages, fully associative, 2 entries",
-     },
-     CacheInfo {
-         num: 0x03,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB: 4 KByte pages, 4-way set associative, 64 entries",
-     },
-     CacheInfo {
-         num: 0x04,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB: 4 MByte pages, 4-way set associative, 8 entries",
-     },
-     CacheInfo {
-         num: 0x05,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB1: 4 MByte pages, 4-way set associative, 32 entries",
-     },
-     CacheInfo {
-         num: 0x06,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level instruction cache: 8 KBytes, 4-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x08,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level instruction cache: 16 KBytes, 4-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x09,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level instruction cache: 32KBytes, 4-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x0A,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level data cache: 8 KBytes, 2-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x0B,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 4 MByte pages, 4-way set associative, 4 entries",
-     },
-     CacheInfo {
-         num: 0x0C,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level data cache: 16 KBytes, 4-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x0D,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level data cache: 16 KBytes, 4-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x0E,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level data cache: 24 KBytes, 6-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x21,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 256 KBytes, 8-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x22,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 512 KBytes, 4-way set associative, 64 byte line size, 2 lines \
-                per sector",
-     },
-     CacheInfo {
-         num: 0x23,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 1 MBytes, 8-way set associative, 64 byte line size, 2 lines per \
-                sector",
-     },
-     CacheInfo {
-         num: 0x24,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 1 MBytes, 16-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x25,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 2 MBytes, 8-way set associative, 64 byte line size, 2 lines per \
-                sector",
-     },
-     CacheInfo {
-         num: 0x29,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 4 MBytes, 8-way set associative, 64 byte line size, 2 lines per \
-                sector",
-     },
-     CacheInfo {
-         num: 0x2C,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level data cache: 32 KBytes, 8-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x30,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level instruction cache: 32 KBytes, 8-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x40,
-         typ: CacheInfoType::CACHE,
-         desc: "No 2nd-level cache or, if processor contains a valid 2nd-level cache, no \
-                3rd-level cache",
-     },
-     CacheInfo {
-         num: 0x41,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 128 KBytes, 4-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x42,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 256 KBytes, 4-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x43,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 512 KBytes, 4-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x44,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 1 MByte, 4-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x45,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 2 MByte, 4-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x46,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 4 MByte, 4-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x47,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 8 MByte, 8-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x48,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 3MByte, 12-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x49,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 4MB, 16-way set associative, 64-byte line size (Intel Xeon \
-                processor MP, Family 0FH, Model 06H); 2nd-level cache: 4 MByte, 16-way set \
+[CacheInfo {
+    num: 0x00,
+    typ: CacheInfoType::GENERAL,
+    desc: "Null descriptor, this byte contains no information",
+},
+CacheInfo {
+    num: 0x01,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 4 KByte pages, 4-way set associative, 32 entries",
+},
+CacheInfo {
+    num: 0x02,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 4 MByte pages, fully associative, 2 entries",
+},
+CacheInfo {
+    num: 0x03,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB: 4 KByte pages, 4-way set associative, 64 entries",
+},
+CacheInfo {
+    num: 0x04,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB: 4 MByte pages, 4-way set associative, 8 entries",
+},
+CacheInfo {
+    num: 0x05,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB1: 4 MByte pages, 4-way set associative, 32 entries",
+},
+CacheInfo {
+    num: 0x06,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level instruction cache: 8 KBytes, 4-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x08,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level instruction cache: 16 KBytes, 4-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x09,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level instruction cache: 32KBytes, 4-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x0A,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level data cache: 8 KBytes, 2-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x0B,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 4 MByte pages, 4-way set associative, 4 entries",
+},
+CacheInfo {
+    num: 0x0C,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level data cache: 16 KBytes, 4-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x0D,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level data cache: 16 KBytes, 4-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x0E,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level data cache: 24 KBytes, 6-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x21,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 256 KBytes, 8-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x22,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 512 KBytes, 4-way set associative, 64 byte line size, 2 lines \
+        per sector",
+},
+CacheInfo {
+    num: 0x23,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 1 MBytes, 8-way set associative, 64 byte line size, 2 lines per \
+        sector",
+},
+CacheInfo {
+    num: 0x24,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 1 MBytes, 16-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x25,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 2 MBytes, 8-way set associative, 64 byte line size, 2 lines per \
+        sector",
+},
+CacheInfo {
+    num: 0x29,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 4 MBytes, 8-way set associative, 64 byte line size, 2 lines per \
+        sector",
+},
+CacheInfo {
+    num: 0x2C,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level data cache: 32 KBytes, 8-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x30,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level instruction cache: 32 KBytes, 8-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x40,
+    typ: CacheInfoType::CACHE,
+    desc: "No 2nd-level cache or, if processor contains a valid 2nd-level cache, no \
+        3rd-level cache",
+},
+CacheInfo {
+    num: 0x41,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 128 KBytes, 4-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x42,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 256 KBytes, 4-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x43,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 512 KBytes, 4-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x44,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 1 MByte, 4-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x45,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 2 MByte, 4-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x46,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 4 MByte, 4-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x47,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 8 MByte, 8-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x48,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 3MByte, 12-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x49,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 4MB, 16-way set associative, 64-byte line size (Intel Xeon \
+        processor MP, Family 0FH, Model 06H); 2nd-level cache: 4 MByte, 16-way set \
                 associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x4A,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 6MByte, 12-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x4B,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 8MByte, 16-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x4C,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 12MByte, 12-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x4D,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 16MByte, 16-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x4E,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 6MByte, 24-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x4F,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 4 KByte pages, 32 entries",
-     },
-     CacheInfo {
-         num: 0x50,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 64 entries",
-     },
-     CacheInfo {
-         num: 0x51,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 128 entries",
-     },
-     CacheInfo {
-         num: 0x52,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 256 entries",
-     },
-     CacheInfo {
-         num: 0x55,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 2-MByte or 4-MByte pages, fully associative, 7 entries",
-     },
-     CacheInfo {
-         num: 0x56,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB0: 4 MByte pages, 4-way set associative, 16 entries",
-     },
-     CacheInfo {
-         num: 0x57,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB0: 4 KByte pages, 4-way associative, 16 entries",
-     },
-     CacheInfo {
-         num: 0x59,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB0: 4 KByte pages, fully associative, 16 entries",
-     },
-     CacheInfo {
-         num: 0x5A,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB0: 2-MByte or 4 MByte pages, 4-way set associative, 32 entries",
-     },
-     CacheInfo {
-         num: 0x5B,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB: 4 KByte and 4 MByte pages, 64 entries",
-     },
-     CacheInfo {
-         num: 0x5C,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB: 4 KByte and 4 MByte pages,128 entries",
-     },
-     CacheInfo {
-         num: 0x5D,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB: 4 KByte and 4 MByte pages,256 entries",
-     },
-     CacheInfo {
-         num: 0x60,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level data cache: 16 KByte, 8-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x61,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 4 KByte pages, fully associative, 48 entries",
-     },
-     CacheInfo {
-         num: 0x63,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB: 1 GByte pages, 4-way set associative, 4 entries",
-     },
-     CacheInfo {
-         num: 0x66,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level data cache: 8 KByte, 4-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x67,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level data cache: 16 KByte, 4-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x68,
-         typ: CacheInfoType::CACHE,
-         desc: "1st-level data cache: 32 KByte, 4-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x6A,
-         typ: CacheInfoType::CACHE,
-         desc: "uTLB: 4 KByte pages, 8-way set associative, 64 entries",
-     },
-     CacheInfo {
-         num: 0x6B,
-         typ: CacheInfoType::CACHE,
-         desc: "DTLB: 4 KByte pages, 8-way set associative, 256 entries",
-     },
-     CacheInfo {
-         num: 0x6C,
-         typ: CacheInfoType::CACHE,
-         desc: "DTLB: 2M/4M pages, 8-way set associative, 128 entries",
-     },
-     CacheInfo {
-         num: 0x6D,
-         typ: CacheInfoType::CACHE,
-         desc: "DTLB: 1 GByte pages, fully associative, 16 entries",
-     },
-     CacheInfo {
-         num: 0x70,
-         typ: CacheInfoType::CACHE,
-         desc: "Trace cache: 12 K-μop, 8-way set associative",
-     },
-     CacheInfo {
-         num: 0x71,
-         typ: CacheInfoType::CACHE,
-         desc: "Trace cache: 16 K-μop, 8-way set associative",
-     },
-     CacheInfo {
-         num: 0x72,
-         typ: CacheInfoType::CACHE,
-         desc: "Trace cache: 32 K-μop, 8-way set associative",
-     },
-     CacheInfo {
-         num: 0x76,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 2M/4M pages, fully associative, 8 entries",
-     },
-     CacheInfo {
-         num: 0x78,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 1 MByte, 4-way set associative, 64byte line size",
-     },
-     CacheInfo {
-         num: 0x79,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 128 KByte, 8-way set associative, 64 byte line size, 2 lines per \
-                sector",
-     },
-     CacheInfo {
-         num: 0x7A,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 256 KByte, 8-way set associative, 64 byte line size, 2 lines per \
-                sector",
-     },
-     CacheInfo {
-         num: 0x7B,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 512 KByte, 8-way set associative, 64 byte line size, 2 lines per \
-                sector",
-     },
-     CacheInfo {
-         num: 0x7C,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 1 MByte, 8-way set associative, 64 byte line size, 2 lines per \
-                sector",
-     },
-     CacheInfo {
-         num: 0x7D,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 2 MByte, 8-way set associative, 64byte line size",
-     },
-     CacheInfo {
-         num: 0x7F,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 512 KByte, 2-way set associative, 64-byte line size",
-     },
-     CacheInfo {
-         num: 0x80,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 512 KByte, 8-way set associative, 64-byte line size",
-     },
-     CacheInfo {
-         num: 0x82,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 256 KByte, 8-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x83,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 512 KByte, 8-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x84,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 1 MByte, 8-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x85,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 2 MByte, 8-way set associative, 32 byte line size",
-     },
-     CacheInfo {
-         num: 0x86,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 512 KByte, 4-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0x87,
-         typ: CacheInfoType::CACHE,
-         desc: "2nd-level cache: 1 MByte, 8-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xB0,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 4 KByte pages, 4-way set associative, 128 entries",
-     },
-     CacheInfo {
-         num: 0xB1,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 2M pages, 4-way, 8 entries or 4M pages, 4-way, 4 entries",
-     },
-     CacheInfo {
-         num: 0xB2,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 4KByte pages, 4-way set associative, 64 entries",
-     },
-     CacheInfo {
-         num: 0xB3,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB: 4 KByte pages, 4-way set associative, 128 entries",
-     },
-     CacheInfo {
-         num: 0xB4,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB1: 4 KByte pages, 4-way associative, 256 entries",
-     },
-     CacheInfo {
-         num: 0xB5,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 4KByte pages, 8-way set associative, 64 entries",
-     },
-     CacheInfo {
-         num: 0xB6,
-         typ: CacheInfoType::TLB,
-         desc: "Instruction TLB: 4KByte pages, 8-way set associative, 128 entries",
-     },
-     CacheInfo {
-         num: 0xBA,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB1: 4 KByte pages, 4-way associative, 64 entries",
-     },
-     CacheInfo {
-         num: 0xC0,
-         typ: CacheInfoType::TLB,
-         desc: "Data TLB: 4 KByte and 4 MByte pages, 4-way associative, 8 entries",
-     },
-     CacheInfo {
-         num: 0xC1,
-         typ: CacheInfoType::STLB,
-         desc: "Shared 2nd-Level TLB: 4 KByte/2MByte pages, 8-way associative, 1024 entries",
-     },
-     CacheInfo {
-         num: 0xC2,
-         typ: CacheInfoType::DTLB,
-         desc: "DTLB: 2 MByte/$MByte pages, 4-way associative, 16 entries",
-     },
-     CacheInfo {
-         num: 0xCA,
-         typ: CacheInfoType::STLB,
-         desc: "Shared 2nd-Level TLB: 4 KByte pages, 4-way associative, 512 entries",
-     },
-     CacheInfo {
-         num: 0xD0,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 512 KByte, 4-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xD1,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 1 MByte, 4-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xD2,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 2 MByte, 4-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xD6,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 1 MByte, 8-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xD7,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 2 MByte, 8-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xD8,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 4 MByte, 8-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xDC,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 1.5 MByte, 12-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xDD,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 3 MByte, 12-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xDE,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 6 MByte, 12-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xE2,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 2 MByte, 16-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xE3,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 4 MByte, 16-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xE4,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 8 MByte, 16-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xEA,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 12MByte, 24-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xEB,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 18MByte, 24-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xEC,
-         typ: CacheInfoType::CACHE,
-         desc: "3rd-level cache: 24MByte, 24-way set associative, 64 byte line size",
-     },
-     CacheInfo {
-         num: 0xF0,
-         typ: CacheInfoType::PREFETCH,
-         desc: "64-Byte prefetching",
-     },
-     CacheInfo {
-         num: 0xF1,
-         typ: CacheInfoType::PREFETCH,
-         desc: "128-Byte prefetching",
-     },
-     CacheInfo {
-         num: 0xFF,
-         typ: CacheInfoType::GENERAL,
-         desc: "CPUID leaf 2 does not report cache descriptor information, use CPUID leaf 4 to \
-                query cache parameters",
-     }];
+},
+CacheInfo {
+    num: 0x4A,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 6MByte, 12-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x4B,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 8MByte, 16-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x4C,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 12MByte, 12-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x4D,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 16MByte, 16-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x4E,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 6MByte, 24-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x4F,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 4 KByte pages, 32 entries",
+},
+CacheInfo {
+    num: 0x50,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 64 entries",
+},
+CacheInfo {
+    num: 0x51,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 128 entries",
+},
+CacheInfo {
+    num: 0x52,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 256 entries",
+},
+CacheInfo {
+    num: 0x55,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 2-MByte or 4-MByte pages, fully associative, 7 entries",
+},
+CacheInfo {
+    num: 0x56,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB0: 4 MByte pages, 4-way set associative, 16 entries",
+},
+CacheInfo {
+    num: 0x57,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB0: 4 KByte pages, 4-way associative, 16 entries",
+},
+CacheInfo {
+    num: 0x59,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB0: 4 KByte pages, fully associative, 16 entries",
+},
+CacheInfo {
+    num: 0x5A,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB0: 2-MByte or 4 MByte pages, 4-way set associative, 32 entries",
+},
+CacheInfo {
+    num: 0x5B,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB: 4 KByte and 4 MByte pages, 64 entries",
+},
+CacheInfo {
+    num: 0x5C,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB: 4 KByte and 4 MByte pages,128 entries",
+},
+CacheInfo {
+    num: 0x5D,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB: 4 KByte and 4 MByte pages,256 entries",
+},
+CacheInfo {
+    num: 0x60,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level data cache: 16 KByte, 8-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x61,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 4 KByte pages, fully associative, 48 entries",
+},
+CacheInfo {
+    num: 0x63,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB: 1 GByte pages, 4-way set associative, 4 entries",
+},
+CacheInfo {
+    num: 0x66,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level data cache: 8 KByte, 4-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x67,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level data cache: 16 KByte, 4-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x68,
+    typ: CacheInfoType::CACHE,
+    desc: "1st-level data cache: 32 KByte, 4-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x6A,
+    typ: CacheInfoType::CACHE,
+    desc: "uTLB: 4 KByte pages, 8-way set associative, 64 entries",
+},
+CacheInfo {
+    num: 0x6B,
+    typ: CacheInfoType::CACHE,
+    desc: "DTLB: 4 KByte pages, 8-way set associative, 256 entries",
+},
+CacheInfo {
+    num: 0x6C,
+    typ: CacheInfoType::CACHE,
+    desc: "DTLB: 2M/4M pages, 8-way set associative, 128 entries",
+},
+CacheInfo {
+    num: 0x6D,
+    typ: CacheInfoType::CACHE,
+    desc: "DTLB: 1 GByte pages, fully associative, 16 entries",
+},
+CacheInfo {
+    num: 0x70,
+    typ: CacheInfoType::CACHE,
+    desc: "Trace cache: 12 K-μop, 8-way set associative",
+},
+CacheInfo {
+    num: 0x71,
+    typ: CacheInfoType::CACHE,
+    desc: "Trace cache: 16 K-μop, 8-way set associative",
+},
+CacheInfo {
+    num: 0x72,
+    typ: CacheInfoType::CACHE,
+    desc: "Trace cache: 32 K-μop, 8-way set associative",
+},
+CacheInfo {
+    num: 0x76,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 2M/4M pages, fully associative, 8 entries",
+},
+CacheInfo {
+    num: 0x78,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 1 MByte, 4-way set associative, 64byte line size",
+},
+CacheInfo {
+    num: 0x79,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 128 KByte, 8-way set associative, 64 byte line size, 2 lines per \
+        sector",
+},
+CacheInfo {
+    num: 0x7A,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 256 KByte, 8-way set associative, 64 byte line size, 2 lines per \
+        sector",
+},
+CacheInfo {
+    num: 0x7B,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 512 KByte, 8-way set associative, 64 byte line size, 2 lines per \
+        sector",
+},
+CacheInfo {
+    num: 0x7C,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 1 MByte, 8-way set associative, 64 byte line size, 2 lines per \
+        sector",
+},
+CacheInfo {
+    num: 0x7D,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 2 MByte, 8-way set associative, 64byte line size",
+},
+CacheInfo {
+    num: 0x7F,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 512 KByte, 2-way set associative, 64-byte line size",
+},
+CacheInfo {
+    num: 0x80,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 512 KByte, 8-way set associative, 64-byte line size",
+},
+CacheInfo {
+    num: 0x82,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 256 KByte, 8-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x83,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 512 KByte, 8-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x84,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 1 MByte, 8-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x85,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 2 MByte, 8-way set associative, 32 byte line size",
+},
+CacheInfo {
+    num: 0x86,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 512 KByte, 4-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0x87,
+    typ: CacheInfoType::CACHE,
+    desc: "2nd-level cache: 1 MByte, 8-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xB0,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 4 KByte pages, 4-way set associative, 128 entries",
+},
+CacheInfo {
+    num: 0xB1,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 2M pages, 4-way, 8 entries or 4M pages, 4-way, 4 entries",
+},
+CacheInfo {
+    num: 0xB2,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 4KByte pages, 4-way set associative, 64 entries",
+},
+CacheInfo {
+    num: 0xB3,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB: 4 KByte pages, 4-way set associative, 128 entries",
+},
+CacheInfo {
+    num: 0xB4,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB1: 4 KByte pages, 4-way associative, 256 entries",
+},
+CacheInfo {
+    num: 0xB5,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 4KByte pages, 8-way set associative, 64 entries",
+},
+CacheInfo {
+    num: 0xB6,
+    typ: CacheInfoType::TLB,
+    desc: "Instruction TLB: 4KByte pages, 8-way set associative, 128 entries",
+},
+CacheInfo {
+    num: 0xBA,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB1: 4 KByte pages, 4-way associative, 64 entries",
+},
+CacheInfo {
+    num: 0xC0,
+    typ: CacheInfoType::TLB,
+    desc: "Data TLB: 4 KByte and 4 MByte pages, 4-way associative, 8 entries",
+},
+CacheInfo {
+    num: 0xC1,
+    typ: CacheInfoType::STLB,
+    desc: "Shared 2nd-Level TLB: 4 KByte/2MByte pages, 8-way associative, 1024 entries",
+},
+CacheInfo {
+    num: 0xC2,
+    typ: CacheInfoType::DTLB,
+    desc: "DTLB: 2 MByte/$MByte pages, 4-way associative, 16 entries",
+},
+CacheInfo {
+    num: 0xCA,
+    typ: CacheInfoType::STLB,
+    desc: "Shared 2nd-Level TLB: 4 KByte pages, 4-way associative, 512 entries",
+},
+CacheInfo {
+    num: 0xD0,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 512 KByte, 4-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xD1,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 1 MByte, 4-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xD2,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 2 MByte, 4-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xD6,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 1 MByte, 8-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xD7,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 2 MByte, 8-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xD8,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 4 MByte, 8-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xDC,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 1.5 MByte, 12-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xDD,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 3 MByte, 12-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xDE,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 6 MByte, 12-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xE2,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 2 MByte, 16-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xE3,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 4 MByte, 16-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xE4,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 8 MByte, 16-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xEA,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 12MByte, 24-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xEB,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 18MByte, 24-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xEC,
+    typ: CacheInfoType::CACHE,
+    desc: "3rd-level cache: 24MByte, 24-way set associative, 64 byte line size",
+},
+CacheInfo {
+    num: 0xF0,
+    typ: CacheInfoType::PREFETCH,
+    desc: "64-Byte prefetching",
+},
+CacheInfo {
+    num: 0xF1,
+    typ: CacheInfoType::PREFETCH,
+    desc: "128-Byte prefetching",
+},
+CacheInfo {
+    num: 0xFF,
+    typ: CacheInfoType::GENERAL,
+    desc: "CPUID leaf 2 does not report cache descriptor information, use CPUID leaf 4 to \
+        query cache parameters",
+}];
 
 impl fmt::Display for VendorInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1244,21 +1248,21 @@ impl FeatureInfo {
 
     check_flag!(doc = "Streaming SIMD Extensions 3 (SSE3). A value of 1 indicates the processor \
                        supports this technology.",
-                has_sse3,
-                edx_ecx,
-                CPU_FEATURE_SSE3);
+                       has_sse3,
+                       edx_ecx,
+                       CPU_FEATURE_SSE3);
 
     check_flag!(doc = "PCLMULQDQ. A value of 1 indicates the processor supports the PCLMULQDQ \
                        instruction",
-                has_pclmulqdq,
-                edx_ecx,
-                CPU_FEATURE_PCLMULQDQ);
+                       has_pclmulqdq,
+                       edx_ecx,
+                       CPU_FEATURE_PCLMULQDQ);
 
     check_flag!(doc = "64-bit DS Area. A value of 1 indicates the processor supports DS area \
                        using 64-bit layout",
-                has_ds_area,
-                edx_ecx,
-                CPU_FEATURE_DTES64);
+                       has_ds_area,
+                       edx_ecx,
+                       CPU_FEATURE_DTES64);
 
     check_flag!(doc = "MONITOR/MWAIT. A value of 1 indicates the processor supports this feature.",
                 has_monitor_mwait,
@@ -1268,80 +1272,80 @@ impl FeatureInfo {
     check_flag!(doc = "CPL Qualified Debug Store. A value of 1 indicates the processor supports \
                        the extensions to the  Debug Store feature to allow for branch message \
                        storage qualified by CPL.",
-                has_cpl,
-                edx_ecx,
-                CPU_FEATURE_DSCPL);
+                       has_cpl,
+                       edx_ecx,
+                       CPU_FEATURE_DSCPL);
 
     check_flag!(doc = "Virtual Machine Extensions. A value of 1 indicates that the processor \
                        supports this technology.",
-                has_vmx,
-                edx_ecx,
-                CPU_FEATURE_VMX);
+                       has_vmx,
+                       edx_ecx,
+                       CPU_FEATURE_VMX);
 
     check_flag!(doc = "Safer Mode Extensions. A value of 1 indicates that the processor supports \
                        this technology. See Chapter 5, Safer Mode Extensions Reference.",
-                has_smx,
-                edx_ecx,
-                CPU_FEATURE_SMX);
+                       has_smx,
+                       edx_ecx,
+                       CPU_FEATURE_SMX);
 
     check_flag!(doc = "Enhanced Intel SpeedStep® technology. A value of 1 indicates that the \
                        processor supports this technology.",
-                has_eist,
-                edx_ecx,
-                CPU_FEATURE_EIST);
+                       has_eist,
+                       edx_ecx,
+                       CPU_FEATURE_EIST);
 
     check_flag!(doc = "Thermal Monitor 2. A value of 1 indicates whether the processor supports \
                        this technology.",
-                has_tm2,
-                edx_ecx,
-                CPU_FEATURE_TM2);
+                       has_tm2,
+                       edx_ecx,
+                       CPU_FEATURE_TM2);
 
     check_flag!(doc = "A value of 1 indicates the presence of the Supplemental Streaming SIMD \
                        Extensions 3 (SSSE3). A value of 0 indicates the instruction extensions \
                        are not present in the processor",
-                has_ssse3,
-                edx_ecx,
-                CPU_FEATURE_SSSE3);
+                       has_ssse3,
+                       edx_ecx,
+                       CPU_FEATURE_SSSE3);
 
     check_flag!(doc = "L1 Context ID. A value of 1 indicates the L1 data cache mode can be set \
                        to either adaptive mode or shared mode. A value of 0 indicates this \
                        feature is not supported. See definition of the IA32_MISC_ENABLE MSR Bit \
                        24 (L1 Data Cache Context Mode) for details.",
-                has_cnxtid,
-                edx_ecx,
-                CPU_FEATURE_CNXTID);
+                       has_cnxtid,
+                       edx_ecx,
+                       CPU_FEATURE_CNXTID);
 
     check_flag!(doc = "A value of 1 indicates the processor supports FMA extensions using YMM \
                        state.",
-                has_fma,
-                edx_ecx,
-                CPU_FEATURE_FMA);
+                       has_fma,
+                       edx_ecx,
+                       CPU_FEATURE_FMA);
 
     check_flag!(doc = "CMPXCHG16B Available. A value of 1 indicates that the feature is \
                        available. See the CMPXCHG8B/CMPXCHG16B Compare and Exchange Bytes \
                        section. 14",
-                has_cmpxchg16b,
-                edx_ecx,
-                CPU_FEATURE_CMPXCHG16B);
+                       has_cmpxchg16b,
+                       edx_ecx,
+                       CPU_FEATURE_CMPXCHG16B);
 
     check_flag!(doc = "Perfmon and Debug Capability: A value of 1 indicates the processor \
                        supports the performance   and debug feature indication MSR \
                        IA32_PERF_CAPABILITIES.",
-                has_pdcm,
-                edx_ecx,
-                CPU_FEATURE_PDCM);
+                       has_pdcm,
+                       edx_ecx,
+                       CPU_FEATURE_PDCM);
 
     check_flag!(doc = "Process-context identifiers. A value of 1 indicates that the processor \
                        supports PCIDs and the software may set CR4.PCIDE to 1.",
-                has_pcid,
-                edx_ecx,
-                CPU_FEATURE_PCID);
+                       has_pcid,
+                       edx_ecx,
+                       CPU_FEATURE_PCID);
 
     check_flag!(doc = "A value of 1 indicates the processor supports the ability to prefetch \
                        data from a memory mapped device.",
-                has_dca,
-                edx_ecx,
-                CPU_FEATURE_DCA);
+                       has_dca,
+                       edx_ecx,
+                       CPU_FEATURE_DCA);
 
     check_flag!(doc = "A value of 1 indicates that the processor supports SSE4.1.",
                 has_sse41,
@@ -1370,41 +1374,41 @@ impl FeatureInfo {
 
     check_flag!(doc = "A value of 1 indicates that the processors local APIC timer supports \
                        one-shot operation using a TSC deadline value.",
-                has_tsc_deadline,
-                edx_ecx,
-                CPU_FEATURE_TSC_DEADLINE);
+                       has_tsc_deadline,
+                       edx_ecx,
+                       CPU_FEATURE_TSC_DEADLINE);
 
     check_flag!(doc = "A value of 1 indicates that the processor supports the AESNI instruction \
                        extensions.",
-                has_aesni,
-                edx_ecx,
-                CPU_FEATURE_AESNI);
+                       has_aesni,
+                       edx_ecx,
+                       CPU_FEATURE_AESNI);
 
     check_flag!(doc = "A value of 1 indicates that the processor supports the XSAVE/XRSTOR \
                        processor extended states feature, the XSETBV/XGETBV instructions, and \
                        XCR0.",
-                has_xsave,
-                edx_ecx,
-                CPU_FEATURE_XSAVE);
+                       has_xsave,
+                       edx_ecx,
+                       CPU_FEATURE_XSAVE);
 
     check_flag!(doc = "A value of 1 indicates that the OS has enabled XSETBV/XGETBV instructions \
                        to access XCR0, and support for processor extended state management using \
                        XSAVE/XRSTOR.",
-                has_oxsave,
-                edx_ecx,
-                CPU_FEATURE_OSXSAVE);
+                       has_oxsave,
+                       edx_ecx,
+                       CPU_FEATURE_OSXSAVE);
 
     check_flag!(doc = "A value of 1 indicates the processor supports the AVX instruction \
                        extensions.",
-                has_avx,
-                edx_ecx,
-                CPU_FEATURE_AVX);
+                       has_avx,
+                       edx_ecx,
+                       CPU_FEATURE_AVX);
 
     check_flag!(doc = "A value of 1 indicates that processor supports 16-bit floating-point \
                        conversion instructions.",
-                has_f16c,
-                edx_ecx,
-                CPU_FEATURE_F16C);
+                       has_f16c,
+                       edx_ecx,
+                       CPU_FEATURE_F16C);
 
     check_flag!(doc = "A value of 1 indicates that processor supports RDRAND instruction.",
                 has_rdrand,
@@ -1420,43 +1424,43 @@ impl FeatureInfo {
                        CR4.VME for controlling the feature, CR4.PVI for protected mode virtual \
                        interrupts, software interrupt indirection, expansion of the TSS with the \
                        software indirection bitmap, and EFLAGS.VIF and EFLAGS.VIP flags.",
-                has_vme,
-                edx_ecx,
-                CPU_FEATURE_VME);
+                       has_vme,
+                       edx_ecx,
+                       CPU_FEATURE_VME);
 
     check_flag!(doc = "Debugging Extensions. Support for I/O breakpoints, including CR4.DE for \
                        controlling the feature, and optional trapping of accesses to DR4 and DR5.",
-                has_de,
-                edx_ecx,
-                CPU_FEATURE_DE);
+                       has_de,
+                       edx_ecx,
+                       CPU_FEATURE_DE);
 
     check_flag!(doc = "Page Size Extension. Large pages of size 4 MByte are supported, including \
                        CR4.PSE for controlling the feature, the defined dirty bit in PDE (Page \
-                       Directory Entries), optional reserved bit trapping in CR3, PDEs, and PTEs.",
-                has_pse,
-                edx_ecx,
-                CPU_FEATURE_PSE);
+                                                                                          Directory Entries), optional reserved bit trapping in CR3, PDEs, and PTEs.",
+                                                                                          has_pse,
+                                                                                          edx_ecx,
+                                                                                          CPU_FEATURE_PSE);
 
     check_flag!(doc = "Time Stamp Counter. The RDTSC instruction is supported, including CR4.TSD \
                        for controlling privilege.",
-                has_tsc,
-                edx_ecx,
-                CPU_FEATURE_TSC);
+                       has_tsc,
+                       edx_ecx,
+                       CPU_FEATURE_TSC);
 
     check_flag!(doc = "Model Specific Registers RDMSR and WRMSR Instructions. The RDMSR and \
                        WRMSR instructions are supported. Some of the MSRs are implementation \
                        dependent.",
-                has_msr,
-                edx_ecx,
-                CPU_FEATURE_MSR);
+                       has_msr,
+                       edx_ecx,
+                       CPU_FEATURE_MSR);
 
     check_flag!(doc = "Physical Address Extension. Physical addresses greater than 32 bits are \
                        supported: extended page table entry formats, an extra level in the page \
                        translation tables is defined, 2-MByte pages are supported instead of 4 \
                        Mbyte pages if PAE bit is 1.",
-                has_pae,
-                edx_ecx,
-                CPU_FEATURE_PAE);
+                       has_pae,
+                       edx_ecx,
+                       CPU_FEATURE_PAE);
 
     check_flag!(doc = "Machine Check Exception. Exception 18 is defined for Machine Checks, \
                        including CR4.MCE for controlling the feature. This feature does not \
@@ -1464,82 +1468,82 @@ impl FeatureInfo {
                        reporting, and processor shutdowns. Machine Check exception handlers may \
                        have to depend on processor version to do model specific processing of \
                        the exception, or test for the presence of the Machine Check feature.",
-                has_mce,
-                edx_ecx,
-                CPU_FEATURE_MCE);
+                       has_mce,
+                       edx_ecx,
+                       CPU_FEATURE_MCE);
 
     check_flag!(doc = "CMPXCHG8B Instruction. The compare-and-exchange 8 bytes (64 bits) \
                        instruction is supported (implicitly locked and atomic).",
-                has_cmpxchg8b,
-                edx_ecx,
-                CPU_FEATURE_CX8);
+                       has_cmpxchg8b,
+                       edx_ecx,
+                       CPU_FEATURE_CX8);
 
     check_flag!(doc = "APIC On-Chip. The processor contains an Advanced Programmable Interrupt \
                        Controller (APIC), responding to memory mapped commands in the physical \
                        address range FFFE0000H to FFFE0FFFH (by default - some processors permit \
                        the APIC to be relocated).",
-                has_apic,
-                edx_ecx,
-                CPU_FEATURE_APIC);
+                       has_apic,
+                       edx_ecx,
+                       CPU_FEATURE_APIC);
 
     check_flag!(doc = "SYSENTER and SYSEXIT Instructions. The SYSENTER and SYSEXIT and \
                        associated MSRs are supported.",
-                has_sysenter_sysexit,
-                edx_ecx,
-                CPU_FEATURE_SEP);
+                       has_sysenter_sysexit,
+                       edx_ecx,
+                       CPU_FEATURE_SEP);
 
     check_flag!(doc = "Memory Type Range Registers. MTRRs are supported. The MTRRcap MSR \
                        contains feature bits that describe what memory types are supported, how \
                        many variable MTRRs are supported, and whether fixed MTRRs are supported.",
-                has_mtrr,
-                edx_ecx,
-                CPU_FEATURE_MTRR);
+                       has_mtrr,
+                       edx_ecx,
+                       CPU_FEATURE_MTRR);
 
     check_flag!(doc = "Page Global Bit. The global bit is supported in paging-structure entries \
                        that map a page, indicating TLB entries that are common to different \
                        processes and need not be flushed. The CR4.PGE bit controls this feature.",
-                has_pge,
-                edx_ecx,
-                CPU_FEATURE_PGE);
+                       has_pge,
+                       edx_ecx,
+                       CPU_FEATURE_PGE);
 
     check_flag!(doc = "Machine Check Architecture. The Machine Check Architecture, which \
                        provides a compatible mechanism for error reporting in P6 family, Pentium \
                        4, Intel Xeon processors, and future processors, is supported. The \
                        MCG_CAP MSR contains feature bits describing how many banks of error \
                        reporting MSRs are supported.",
-                has_mca,
-                edx_ecx,
-                CPU_FEATURE_MCA);
+                       has_mca,
+                       edx_ecx,
+                       CPU_FEATURE_MCA);
 
     check_flag!(doc = "Conditional Move Instructions. The conditional move instruction CMOV is \
                        supported. In addition, if x87 FPU is present as indicated by the \
                        CPUID.FPU feature bit, then the FCOMI and FCMOV instructions are supported",
-                has_cmov,
-                edx_ecx,
-                CPU_FEATURE_CMOV);
+                       has_cmov,
+                       edx_ecx,
+                       CPU_FEATURE_CMOV);
 
     check_flag!(doc = "Page Attribute Table. Page Attribute Table is supported. This feature \
                        augments the Memory Type Range Registers (MTRRs), allowing an operating \
                        system to specify attributes of memory accessed through a linear address \
                        on a 4KB granularity.",
-                has_pat,
-                edx_ecx,
-                CPU_FEATURE_PAT);
+                       has_pat,
+                       edx_ecx,
+                       CPU_FEATURE_PAT);
 
     check_flag!(doc = "36-Bit Page Size Extension. 4-MByte pages addressing physical memory \
                        beyond 4 GBytes are supported with 32-bit paging. This feature indicates \
                        that upper bits of the physical address of a 4-MByte page are encoded in \
                        bits 20:13 of the page-directory entry. Such physical addresses are \
                        limited by MAXPHYADDR and may be up to 40 bits in size.",
-                has_pse36,
-                edx_ecx,
-                CPU_FEATURE_PSE36);
+                       has_pse36,
+                       edx_ecx,
+                       CPU_FEATURE_PSE36);
 
     check_flag!(doc = "Processor Serial Number. The processor supports the 96-bit processor \
                        identification number feature and the feature is enabled.",
-                has_psn,
-                edx_ecx,
-                CPU_FEATURE_PSN);
+                       has_psn,
+                       edx_ecx,
+                       CPU_FEATURE_PSN);
 
     check_flag!(doc = "CLFLUSH Instruction. CLFLUSH Instruction is supported.",
                 has_clflush,
@@ -1550,19 +1554,19 @@ impl FeatureInfo {
                        information into a memory resident buffer. This feature is used by the \
                        branch trace store (BTS) and precise event-based sampling (PEBS) \
                        facilities (see Chapter 23, Introduction to Virtual-Machine Extensions, \
-                       in the Intel® 64 and IA-32 Architectures Software Developers Manual, \
+                                   in the Intel® 64 and IA-32 Architectures Software Developers Manual, \
                        Volume 3C).",
-                has_ds,
-                edx_ecx,
-                CPU_FEATURE_DS);
+                       has_ds,
+                       edx_ecx,
+                       CPU_FEATURE_DS);
 
     check_flag!(doc = "Thermal Monitor and Software Controlled Clock Facilities. The processor \
                        implements internal MSRs that allow processor temperature to be monitored \
                        and processor performance to be modulated in predefined duty cycles under \
                        software control.",
-                has_acpi,
-                edx_ecx,
-                CPU_FEATURE_ACPI);
+                       has_acpi,
+                       edx_ecx,
+                       CPU_FEATURE_ACPI);
 
     check_flag!(doc = "Intel MMX Technology. The processor supports the Intel MMX technology.",
                 has_mmx,
@@ -1574,9 +1578,9 @@ impl FeatureInfo {
                        Presence of this bit also indicates that CR4.OSFXSR is available for an \
                        operating system to indicate that it supports the FXSAVE and FXRSTOR \
                        instructions.",
-                has_fxsave_fxstor,
-                edx_ecx,
-                CPU_FEATURE_FXSR);
+                       has_fxsave_fxstor,
+                       edx_ecx,
+                       CPU_FEATURE_FXSR);
 
     check_flag!(doc = "SSE. The processor supports the SSE extensions.",
                 has_sse,
@@ -1591,34 +1595,34 @@ impl FeatureInfo {
     check_flag!(doc = "Self Snoop. The processor supports the management of conflicting memory \
                        types by performing a snoop of its own cache structure for transactions \
                        issued to the bus.",
-                has_ss,
-                edx_ecx,
-                CPU_FEATURE_SS);
+                       has_ss,
+                       edx_ecx,
+                       CPU_FEATURE_SS);
 
     check_flag!(doc = "Max APIC IDs reserved field is Valid. A value of 0 for HTT indicates \
                        there is only a single logical processor in the package and software \
                        should assume only a single APIC ID is reserved.  A value of 1 for HTT \
                        indicates the value in CPUID.1.EBX[23:16] (the Maximum number of \
-                       addressable IDs for logical processors in this package) is valid for the \
+                                                                  addressable IDs for logical processors in this package) is valid for the \
                        package.",
-                has_htt,
-                edx_ecx,
-                CPU_FEATURE_HTT);
+                       has_htt,
+                       edx_ecx,
+                       CPU_FEATURE_HTT);
 
     check_flag!(doc = "Thermal Monitor. The processor implements the thermal monitor automatic \
                        thermal control circuitry (TCC).",
-                has_tm,
-                edx_ecx,
-                CPU_FEATURE_TM);
+                       has_tm,
+                       edx_ecx,
+                       CPU_FEATURE_TM);
 
     check_flag!(doc = "Pending Break Enable. The processor supports the use of the FERR#/PBE# \
                        pin when the processor is in the stop-clock state (STPCLK# is asserted) \
                        to signal the processor that an interrupt is pending and that the \
                        processor should return to normal operation to handle the interrupt. Bit \
                        10 (PBE enable) in the IA32_MISC_ENABLE MSR enables this capability.",
-                has_pbe,
-                edx_ecx,
-                CPU_FEATURE_PBE);
+                       has_pbe,
+                       edx_ecx,
+                       CPU_FEATURE_PBE);
 }
 
 bitflags! {
@@ -1963,9 +1967,9 @@ impl ThermalPowerInfo {
 
     check_flag!(doc = "Intel Turbo Boost Technology Available (see description of \
                        IA32_MISC_ENABLE[38]).",
-                has_turbo_boost,
-                eax,
-                CPU_FEATURE_TURBO_BOOST);
+                       has_turbo_boost,
+                       eax,
+                       CPU_FEATURE_TURBO_BOOST);
 
     check_flag!(doc = "ARAT. APIC-Timer-always-running feature is supported if set.",
                 has_arat,
@@ -1992,16 +1996,16 @@ impl ThermalPowerInfo {
                        performance (since last reset of the counters), as a percentage of \
                        expected processor performance at frequency specified in CPUID Brand \
                        String Bits 02 - 01",
-                has_hw_coord_feedback,
-                ecx,
-                CPU_FEATURE_HW_COORD_FEEDBACK);
+                       has_hw_coord_feedback,
+                       ecx,
+                       CPU_FEATURE_HW_COORD_FEEDBACK);
 
     check_flag!(doc = "The processor supports performance-energy bias preference if \
                        CPUID.06H:ECX.SETBH[bit 3] is set and it also implies the presence of a \
                        new architectural MSR called IA32_ENERGY_PERF_BIAS (1B0H)",
-                has_energy_bias_pref,
-                ecx,
-                CPU_FEATURE_ENERGY_BIAS_PREF);
+                       has_energy_bias_pref,
+                       ecx,
+                       CPU_FEATURE_ENERGY_BIAS_PREF);
 }
 
 bitflags! {
@@ -2082,16 +2086,16 @@ impl ExtendedFeatures {
 
     check_flag!(doc = "INVPCID. If 1, supports INVPCID instruction for system software that \
                        manages process-context identifiers.",
-                has_invpcid,
-                ebx,
-                CPU_FEATURE_INVPCID);
+                       has_invpcid,
+                       ebx,
+                       CPU_FEATURE_INVPCID);
 
     check_flag!(doc = "RTM", has_rtm, ebx, CPU_FEATURE_RTM);
 
     check_flag!(doc = "Supports Quality of Service Monitoring (QM) capability if 1.",
-                has_qm,
-                ebx,
-                CPU_FEATURE_QM);
+    has_qm,
+    ebx,
+    CPU_FEATURE_QM);
 
     check_flag!(doc = "Deprecates FPU CS and FPU DS values if 1.",
                 has_fpu_cs_ds_deprecated,
@@ -2104,9 +2108,9 @@ impl ExtendedFeatures {
                 CPU_FEATURE_MPX);
 
     check_flag!(doc = "Supports Platform Quality of Service Enforcement (PQE) capability if 1.",
-                has_pqe,
-                ebx,
-                CPU_FEATURE_PQE);
+    has_pqe,
+    ebx,
+    CPU_FEATURE_PQE);
 
     check_flag!(doc = "Supports RDSEED.",
                 has_rdseet,
@@ -2119,9 +2123,9 @@ impl ExtendedFeatures {
                 CPU_FEATURE_ADX);
 
     check_flag!(doc = "SMAP. Supports Supervisor-Mode Access Prevention (and the CLAC/STAC instructions) if 1.",
-                has_smap,
-                ebx,
-                CPU_FEATURE_SMAP);
+    has_smap,
+    ebx,
+    CPU_FEATURE_SMAP);
 
     check_flag!(doc = "Supports CLFLUSHOPT.",
                 has_clflushopt,
@@ -2405,7 +2409,7 @@ macro_rules! check_xcr_flag {
         pub fn $fun(&self) -> bool {
             self.xcr0_supported() & (ExtendedStateIdent::$flag as u64) > 0
         }
-    )
+        )
 }
 
 impl ExtendedStateInfo {
@@ -2690,37 +2694,37 @@ impl ProcessorTraceInfo {
     // EBX features
     check_bit_fn!(doc = "If true, Indicates that IA32_RTIT_CTL.CR3Filter can be set to 1, and \
                          that IA32_RTIT_CR3_MATCH MSR can be accessed.",
-                  has_rtit_cr3_match,
-                  ebx,
-                  0);
+                         has_rtit_cr3_match,
+                         ebx,
+                         0);
     check_bit_fn!(doc = "If true, Indicates support of Configurable PSB and Cycle-Accurate Mode.",
                   has_configurable_psb_and_cycle_accurate_mode,
                   ebx,
                   1);
     check_bit_fn!(doc = "If true, Indicates support of IP Filtering, TraceStop filtering, and \
                          preservation of Intel PT MSRs across warm reset.",
-                  has_ip_tracestop_filtering,
-                  ebx,
-                  2);
+                         has_ip_tracestop_filtering,
+                         ebx,
+                         2);
     check_bit_fn!(doc = "If true, Indicates support of MTC timing packet and suppression of \
                          COFI-based packets.",
-                  has_mtc_timing_packet_coefi_suppression,
-                  ebx,
-                  3);
+                         has_mtc_timing_packet_coefi_suppression,
+                         ebx,
+                         3);
 
     // ECX features
     check_bit_fn!(doc = "If true, Tracing can be enabled with IA32_RTIT_CTL.ToPA = 1, hence \
                          utilizing the ToPA output scheme; IA32_RTIT_OUTPUT_BASE and \
                          IA32_RTIT_OUTPUT_MASK_PTRS MSRs can be accessed.",
-                  has_topa,
-                  ecx,
-                  0);
+                         has_topa,
+                         ecx,
+                         0);
     check_bit_fn!(doc = "If true, ToPA tables can hold any number of output entries, up to the \
                          maximum allowed by the MaskOrTableOffset field of \
                          IA32_RTIT_OUTPUT_MASK_PTRS.",
-                  has_topa_maximum_entries,
-                  ecx,
-                  1);
+                         has_topa_maximum_entries,
+                         ecx,
+                         1);
     check_bit_fn!(doc = "If true, Indicates support of Single-Range Output scheme.",
                   has_single_range_output_scheme,
                   ecx,
@@ -2731,9 +2735,9 @@ impl ProcessorTraceInfo {
                   3);
     check_bit_fn!(doc = "If true, Generated packets which contain IP payloads have LIP values, \
                          which include the CS base component.",
-                  has_lip_with_cs_base,
-                  ecx,
-                  31);
+                         has_lip_with_cs_base,
+                         ecx,
+                         31);
 
     /// Iterator over processor trace info sub-leafs.
     pub fn iter(&self) -> ProcessorTraceIter {
@@ -3037,49 +3041,49 @@ impl ExtendedFunctionInfo {
     /// Is LAHF/SAHF available in 64-bit mode?
     pub fn has_lahf_sahf(&self) -> bool {
         self.leaf_is_supported(1) &&
-        ExtendedFunctionInfoEcx { bits: self.data[1].ecx }.contains(CPU_FEATURE_LAHF_SAHF)
+            ExtendedFunctionInfoEcx { bits: self.data[1].ecx }.contains(CPU_FEATURE_LAHF_SAHF)
     }
 
     /// Is LZCNT available?
     pub fn has_lzcnt(&self) -> bool {
         self.leaf_is_supported(1) &&
-        ExtendedFunctionInfoEcx { bits: self.data[1].ecx }.contains(CPU_FEATURE_LZCNT)
+            ExtendedFunctionInfoEcx { bits: self.data[1].ecx }.contains(CPU_FEATURE_LZCNT)
     }
 
     /// Is PREFETCHW available?
     pub fn has_prefetchw(&self) -> bool {
         self.leaf_is_supported(1) &&
-        ExtendedFunctionInfoEcx { bits: self.data[1].ecx }.contains(CPU_FEATURE_PREFETCHW)
+            ExtendedFunctionInfoEcx { bits: self.data[1].ecx }.contains(CPU_FEATURE_PREFETCHW)
     }
 
     /// Are fast system calls available.
     pub fn has_syscall_sysret(&self) -> bool {
         self.leaf_is_supported(1) &&
-        ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_SYSCALL_SYSRET)
+            ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_SYSCALL_SYSRET)
     }
 
     /// Is there support for execute disable bit.
     pub fn has_execute_disable(&self) -> bool {
         self.leaf_is_supported(1) &&
-        ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_EXECUTE_DISABLE)
+            ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_EXECUTE_DISABLE)
     }
 
     /// Is there support for 1GiB pages.
     pub fn has_1gib_pages(&self) -> bool {
         self.leaf_is_supported(1) &&
-        ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_1GIB_PAGES)
+            ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_1GIB_PAGES)
     }
 
     /// Check support for rdtscp instruction.
     pub fn has_rdtscp(&self) -> bool {
         self.leaf_is_supported(1) &&
-        ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_RDTSCP)
+            ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_RDTSCP)
     }
 
     /// Check support for 64-bit mode.
     pub fn has_64bit_mode(&self) -> bool {
         self.leaf_is_supported(1) &&
-        ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_64BIT_MODE)
+            ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_64BIT_MODE)
     }
 }
 
@@ -3166,29 +3170,29 @@ fn cache_info() {
 #[test]
 fn cache_parameters() {
     let caches: [CacheParameter; 4] = [CacheParameter {
-                                           eax: 469778721,
-                                           ebx: 29360191,
-                                           ecx: 63,
-                                           edx: 0,
-                                       },
-                                       CacheParameter {
-                                           eax: 469778722,
-                                           ebx: 29360191,
-                                           ecx: 63,
-                                           edx: 0,
-                                       },
-                                       CacheParameter {
-                                           eax: 469778755,
-                                           ebx: 29360191,
-                                           ecx: 511,
-                                           edx: 0,
-                                       },
-                                       CacheParameter {
-                                           eax: 470008163,
-                                           ebx: 46137407,
-                                           ecx: 4095,
-                                           edx: 6,
-                                       }];
+        eax: 469778721,
+        ebx: 29360191,
+        ecx: 63,
+        edx: 0,
+    },
+    CacheParameter {
+        eax: 469778722,
+        ebx: 29360191,
+        ecx: 63,
+        edx: 0,
+    },
+    CacheParameter {
+        eax: 469778755,
+        ebx: 29360191,
+        ecx: 511,
+        edx: 0,
+    },
+    CacheParameter {
+        eax: 470008163,
+        ebx: 46137407,
+        ecx: 4095,
+        edx: 6,
+    }];
 
 
     for (idx, cache) in caches.into_iter().enumerate() {
@@ -3438,59 +3442,59 @@ fn extended_functions() {
     let ef = ExtendedFunctionInfo {
         max_eax_value: 8,
         data: [CpuIdResult {
-                   eax: 2147483656,
-                   ebx: 0,
-                   ecx: 0,
-                   edx: 0,
-               },
-               CpuIdResult {
-                   eax: 0,
-                   ebx: 0,
-                   ecx: 1,
-                   edx: 672139264,
-               },
-               CpuIdResult {
-                   eax: 538976288,
-                   ebx: 1226842144,
-                   ecx: 1818588270,
-                   edx: 539578920,
-               },
-               CpuIdResult {
-                   eax: 1701998403,
-                   ebx: 692933672,
-                   ecx: 758475040,
-                   edx: 926102323,
-               },
-               CpuIdResult {
-                   eax: 1346576469,
-                   ebx: 541073493,
-                   ecx: 808988209,
-                   edx: 8013895,
-               },
-               CpuIdResult {
-                   eax: 0,
-                   ebx: 0,
-                   ecx: 0,
-                   edx: 0,
-               },
-               CpuIdResult {
-                   eax: 0,
-                   ebx: 0,
-                   ecx: 16801856,
-                   edx: 0,
-               },
-               CpuIdResult {
-                   eax: 0,
-                   ebx: 0,
-                   ecx: 0,
-                   edx: 256,
-               },
-               CpuIdResult {
-                   eax: 12324,
-                   ebx: 0,
-                   ecx: 0,
-                   edx: 0,
-               }],
+            eax: 2147483656,
+            ebx: 0,
+            ecx: 0,
+            edx: 0,
+        },
+        CpuIdResult {
+            eax: 0,
+            ebx: 0,
+            ecx: 1,
+            edx: 672139264,
+        },
+        CpuIdResult {
+            eax: 538976288,
+            ebx: 1226842144,
+            ecx: 1818588270,
+            edx: 539578920,
+        },
+        CpuIdResult {
+            eax: 1701998403,
+            ebx: 692933672,
+            ecx: 758475040,
+            edx: 926102323,
+        },
+        CpuIdResult {
+            eax: 1346576469,
+            ebx: 541073493,
+            ecx: 808988209,
+            edx: 8013895,
+        },
+        CpuIdResult {
+            eax: 0,
+            ebx: 0,
+            ecx: 0,
+            edx: 0,
+        },
+        CpuIdResult {
+            eax: 0,
+            ebx: 0,
+            ecx: 16801856,
+            edx: 0,
+        },
+        CpuIdResult {
+            eax: 0,
+            ebx: 0,
+            ecx: 0,
+            edx: 256,
+        },
+        CpuIdResult {
+            eax: 12324,
+            ebx: 0,
+            ecx: 0,
+            edx: 0,
+        }],
     };
 
     assert!(ef.processor_brand_string().unwrap() ==

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2961,13 +2961,7 @@ impl ExtendedFunctionInfo {
         if self.leaf_is_supported(EAX_EXTENDED_BRAND_STRING) {
             Some(unsafe {
                 let brand_string_start = transmute::<&CpuIdResult, *const u8>(&self.data[2]);
-                let mut slice = slice::from_raw_parts(brand_string_start, 3 * 4 * 4);
-
-                match slice.iter().position(|&x| x == 0) {
-                    Some(index) => slice = slice::from_raw_parts(brand_string_start, index),
-                    None => (),
-                }
-
+                let slice = slice::from_raw_parts(brand_string_start, 3 * 4 * 4);
                 let byte_array: &'static [u8] = transmute(slice);
                 str::from_utf8_unchecked(byte_array)
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(asm))]
-
 #![feature(asm)]
 
 #![crate_name = "raw_cpuid"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,11 @@ extern crate bitflags;
 #[macro_use]
 extern crate std;
 
-unsafe fn c_cpuid(a: *mut u32, b: *mut u32, c: *mut u32, d: *mut u32) {
+unsafe fn c_cpuid(a: &mut u32, b: &mut u32, c: &mut u32, d: &mut u32) {
     asm!("cpuid"
-         : "+{eax}"(*a), "={ebx}"(*b), "+{ecx}"(*c), "={edx}"(*d)
-         : : : "volatile")
+      : "+{eax}"(*a), "={ebx}"(*b), "+{ecx}"(*c), "={edx}"(*d)
+      : : : "volatile"
+    );
 }
 
 use core::str;
@@ -106,13 +107,13 @@ macro_rules! check_flag {
         pub fn $fun(&self) -> bool {
             self.$flags.contains($flag)
         }
-        )
+    )
 }
 
 macro_rules! is_bit_set {
     ($field:expr, $bit:expr) => (
         $field & (1 << $bit) > 0
-        )
+    )
 }
 
 macro_rules! check_bit_fn {
@@ -121,7 +122,7 @@ macro_rules! check_bit_fn {
         pub fn $fun(&self) -> bool {
             is_bit_set!(self.$field, $bit)
         }
-        )
+    )
 }
 
 /// Main type used to query for information about the CPU we're running on.
@@ -143,375 +144,375 @@ pub struct CpuIdResult {
     pub edx: u32,
 }
 
-    const EAX_VENDOR_INFO: u32 = 0x0;
-    const EAX_FEATURE_INFO: u32 = 0x1;
-    const EAX_CACHE_INFO: u32 = 0x2;
-    const EAX_PROCESSOR_SERIAL: u32 = 0x3;
-    const EAX_CACHE_PARAMETERS: u32 = 0x4;
-    const EAX_MONITOR_MWAIT_INFO: u32 = 0x5;
-    const EAX_THERMAL_POWER_INFO: u32 = 0x6;
-    const EAX_STRUCTURED_EXTENDED_FEATURE_INFO: u32 = 0x7;
-    const EAX_DIRECT_CACHE_ACCESS_INFO: u32 = 0x9;
-    const EAX_PERFORMANCE_MONITOR_INFO: u32 = 0xA;
-    const EAX_EXTENDED_TOPOLOGY_INFO: u32 = 0xB;
-    const EAX_EXTENDED_STATE_INFO: u32 = 0xD;
-    const EAX_QOS_INFO: u32 = 0xF;
-    const EAX_QOS_ENFORCEMENT_INFO: u32 = 0x10;
-    const EAX_TRACE_INFO: u32 = 0x14;
-    const EAX_TIME_STAMP_COUNTER_INFO: u32 = 0x15;
-    const EAX_FREQUENCY_INFO: u32 = 0x16;
-    const EAX_SOC_VENDOR_INFO: u32 = 0x17;
-    const EAX_EXTENDED_FUNCTION_INFO: u32 = 0x80000000;
+const EAX_VENDOR_INFO: u32 = 0x0;
+const EAX_FEATURE_INFO: u32 = 0x1;
+const EAX_CACHE_INFO: u32 = 0x2;
+const EAX_PROCESSOR_SERIAL: u32 = 0x3;
+const EAX_CACHE_PARAMETERS: u32 = 0x4;
+const EAX_MONITOR_MWAIT_INFO: u32 = 0x5;
+const EAX_THERMAL_POWER_INFO: u32 = 0x6;
+const EAX_STRUCTURED_EXTENDED_FEATURE_INFO: u32 = 0x7;
+const EAX_DIRECT_CACHE_ACCESS_INFO: u32 = 0x9;
+const EAX_PERFORMANCE_MONITOR_INFO: u32 = 0xA;
+const EAX_EXTENDED_TOPOLOGY_INFO: u32 = 0xB;
+const EAX_EXTENDED_STATE_INFO: u32 = 0xD;
+const EAX_QOS_INFO: u32 = 0xF;
+const EAX_QOS_ENFORCEMENT_INFO: u32 = 0x10;
+const EAX_TRACE_INFO: u32 = 0x14;
+const EAX_TIME_STAMP_COUNTER_INFO: u32 = 0x15;
+const EAX_FREQUENCY_INFO: u32 = 0x16;
+const EAX_SOC_VENDOR_INFO: u32 = 0x17;
+const EAX_EXTENDED_FUNCTION_INFO: u32 = 0x80000000;
 
-    impl CpuId {
-        /// Return new CPUID struct.
-        pub fn new() -> CpuId {
+impl CpuId {
+    /// Return new CPUID struct.
+    pub fn new() -> CpuId {
+        let res = cpuid!(EAX_VENDOR_INFO);
+        CpuId { max_eax_value: res.eax }
+    }
+
+    fn leaf_is_supported(&self, val: u32) -> bool {
+        val <= self.max_eax_value
+    }
+
+    /// Return information about vendor.
+    /// This is typically a ASCII readable string such as
+    /// GenuineIntel for Intel CPUs or AuthenticAMD for AMD CPUs.
+    pub fn get_vendor_info(&self) -> Option<VendorInfo> {
+        if self.leaf_is_supported(EAX_VENDOR_INFO) {
             let res = cpuid!(EAX_VENDOR_INFO);
-            CpuId { max_eax_value: res.eax }
+            Some(VendorInfo {
+                ebx: res.ebx,
+                ecx: res.ecx,
+                edx: res.edx,
+            })
+        } else {
+            None
         }
+    }
 
-        fn leaf_is_supported(&self, val: u32) -> bool {
-            val <= self.max_eax_value
+    /// Query a set of features that are available on this CPU.
+    pub fn get_feature_info(&self) -> Option<FeatureInfo> {
+        if self.leaf_is_supported(EAX_FEATURE_INFO) {
+            let res = cpuid!(EAX_FEATURE_INFO);
+            Some(FeatureInfo {
+                eax: res.eax,
+                ebx: res.ebx,
+                edx_ecx: FeatureInfoFlags { bits: (((res.edx as u64) << 32) | (res.ecx as u64)) },
+            })
+        } else {
+            None
         }
+    }
 
-        /// Return information about vendor.
-        /// This is typically a ASCII readable string such as
-        /// GenuineIntel for Intel CPUs or AuthenticAMD for AMD CPUs.
-        pub fn get_vendor_info(&self) -> Option<VendorInfo> {
-            if self.leaf_is_supported(EAX_VENDOR_INFO) {
-                let res = cpuid!(EAX_VENDOR_INFO);
-                Some(VendorInfo {
-                    ebx: res.ebx,
-                    ecx: res.ecx,
-                    edx: res.edx,
-                })
-            } else {
-                None
-            }
+    /// Query basic information about caches. This will just return an index
+    /// into a static table of cache descriptions (see `CACHE_INFO_TABLE`).
+    pub fn get_cache_info(&self) -> Option<CacheInfoIter> {
+        if self.leaf_is_supported(EAX_CACHE_INFO) {
+            let res = cpuid!(EAX_CACHE_INFO);
+            Some(CacheInfoIter {
+                current: 1,
+                eax: res.eax,
+                ebx: res.ebx,
+                ecx: res.ecx,
+                edx: res.edx,
+            })
+        } else {
+            None
         }
+    }
 
-        /// Query a set of features that are available on this CPU.
-        pub fn get_feature_info(&self) -> Option<FeatureInfo> {
-            if self.leaf_is_supported(EAX_FEATURE_INFO) {
-                let res = cpuid!(EAX_FEATURE_INFO);
-                Some(FeatureInfo {
-                    eax: res.eax,
-                    ebx: res.ebx,
-                    edx_ecx: FeatureInfoFlags { bits: (((res.edx as u64) << 32) | (res.ecx as u64)) },
-                })
-            } else {
-                None
-            }
-        }
-
-        /// Query basic information about caches. This will just return an index
-        /// into a static table of cache descriptions (see `CACHE_INFO_TABLE`).
-        pub fn get_cache_info(&self) -> Option<CacheInfoIter> {
-            if self.leaf_is_supported(EAX_CACHE_INFO) {
-                let res = cpuid!(EAX_CACHE_INFO);
-                Some(CacheInfoIter {
-                    current: 1,
-                    eax: res.eax,
-                    ebx: res.ebx,
-                    ecx: res.ecx,
-                    edx: res.edx,
-                })
-            } else {
-                None
-            }
-        }
-
-        /// Retrieve serial number of processor.
-        pub fn get_processor_serial(&self) -> Option<ProcessorSerial> {
-            if self.leaf_is_supported(EAX_PROCESSOR_SERIAL) {
-                let res = cpuid!(EAX_PROCESSOR_SERIAL);
-                Some(ProcessorSerial {
-                    ecx: res.ecx,
-                    edx: res.edx,
-                })
-            } else {
-                None
-            }
-
-        }
-
-        /// Retrieve more elaborate information about caches (as opposed
-        /// to `get_cache_info`). This will tell us about associativity,
-        /// set size, line size etc. for each level of the cache hierarchy.
-        pub fn get_cache_parameters(&self) -> Option<CacheParametersIter> {
-            if self.leaf_is_supported(EAX_CACHE_PARAMETERS) {
-                Some(CacheParametersIter { current: 0 })
-            } else {
-                None
-            }
-        }
-
-        /// Information about how monitor/mwait works on this CPU.
-        pub fn get_monitor_mwait_info(&self) -> Option<MonitorMwaitInfo> {
-            if self.leaf_is_supported(EAX_MONITOR_MWAIT_INFO) {
-                let res = cpuid!(EAX_MONITOR_MWAIT_INFO);
-                Some(MonitorMwaitInfo {
-                    eax: res.eax,
-                    ebx: res.ebx,
-                    ecx: res.ecx,
-                    edx: res.edx,
-                })
-            } else {
-                None
-            }
-        }
-
-        /// Query information about thermal and power management features of the CPU.
-        pub fn get_thermal_power_info(&self) -> Option<ThermalPowerInfo> {
-            if self.leaf_is_supported(EAX_THERMAL_POWER_INFO) {
-                let res = cpuid!(EAX_THERMAL_POWER_INFO);
-                Some(ThermalPowerInfo {
-                    eax: ThermalPowerFeaturesEax { bits: res.eax },
-                    ebx: res.ebx,
-                    ecx: ThermalPowerFeaturesEcx { bits: res.ecx },
-                    edx: res.edx,
-                })
-            } else {
-                None
-            }
-        }
-
-        /// Find out about more features supported by this CPU.
-        pub fn get_extended_feature_info(&self) -> Option<ExtendedFeatures> {
-            if self.leaf_is_supported(EAX_STRUCTURED_EXTENDED_FEATURE_INFO) {
-                let res = cpuid!(EAX_STRUCTURED_EXTENDED_FEATURE_INFO);
-                assert!(res.eax == 0);
-                Some(ExtendedFeatures {
-                    eax: res.eax,
-                    ebx: ExtendedFeaturesEbx { bits: res.ebx },
-                    ecx: res.ecx,
-                    edx: res.edx,
-                })
-            } else {
-                None
-            }
-
-        }
-
-        /// Direct cache access info.
-        pub fn get_direct_cache_access_info(&self) -> Option<DirectCacheAccessInfo> {
-            if self.leaf_is_supported(EAX_DIRECT_CACHE_ACCESS_INFO) {
-                let res = cpuid!(EAX_DIRECT_CACHE_ACCESS_INFO);
-                Some(DirectCacheAccessInfo { eax: res.eax })
-            } else {
-                None
-            }
-        }
-
-        /// Info about performance monitoring (how many counters etc.).
-        pub fn get_performance_monitoring_info(&self) -> Option<PerformanceMonitoringInfo> {
-            if self.leaf_is_supported(EAX_PERFORMANCE_MONITOR_INFO) {
-                let res = cpuid!(EAX_PERFORMANCE_MONITOR_INFO);
-                Some(PerformanceMonitoringInfo {
-                    eax: res.eax,
-                    ebx: PerformanceMonitoringFeaturesEbx { bits: res.ebx },
-                    ecx: res.ecx,
-                    edx: res.edx,
-                })
-            } else {
-                None
-            }
-        }
-
-        /// Information about topology (how many cores and what kind of cores).
-        pub fn get_extended_topology_info(&self) -> Option<ExtendedTopologyIter> {
-            if self.leaf_is_supported(EAX_EXTENDED_TOPOLOGY_INFO) {
-                Some(ExtendedTopologyIter { level: 0 })
-            } else {
-                None
-            }
-        }
-
-        /// Information for saving/restoring extended register state.
-        pub fn get_extended_state_info(&self) -> Option<ExtendedStateInfo> {
-            if self.leaf_is_supported(EAX_EXTENDED_STATE_INFO) {
-                let res = cpuid!(EAX_EXTENDED_STATE_INFO, 0);
-                let res1 = cpuid!(EAX_EXTENDED_STATE_INFO, 1);
-                Some(ExtendedStateInfo {
-                    eax: res.eax,
-                    ebx: res.ebx,
-                    ecx: res.ecx,
-                    edx: res.edx,
-                    eax1: res1.eax,
-                })
-            } else {
-                None
-            }
-        }
-
-        /// Quality of service informations.
-        pub fn get_qos_info(&self) -> Option<QoSInfo> {
-            let res = cpuid!(EAX_QOS_INFO, 0);
-            let res1 = cpuid!(EAX_QOS_INFO, 1);
-
-            if self.leaf_is_supported(EAX_QOS_INFO) {
-                Some(QoSInfo {
-                    ebx0: res.ebx,
-                    edx0: res.edx,
-                    ebx1: res1.ebx,
-                    ecx1: res1.ecx,
-                    edx1: res1.edx,
-                })
-            } else {
-                None
-            }
-        }
-
-        /// Quality of service enforcement information.
-        pub fn get_qos_enforcement_info(&self) -> Option<QoSEnforcementInfo> {
-            let res = cpuid!(EAX_QOS_ENFORCEMENT_INFO, 0);
-            let res1 = cpuid!(EAX_QOS_ENFORCEMENT_INFO, 1);
-
-            if self.leaf_is_supported(EAX_QOS_ENFORCEMENT_INFO) {
-                Some(QoSEnforcementInfo {
-                    ebx0: res.ebx,
-                    eax1: res1.eax,
-                    ebx1: res1.ebx,
-                    ecx1: res1.ecx,
-                    edx1: res1.edx,
-                })
-            } else {
-                None
-            }
-        }
-
-        /// Intel Processor Trace Enumeration Information.
-        pub fn get_processor_trace_info(&self) -> Option<ProcessorTraceInfo> {
-            let res = cpuid!(EAX_TRACE_INFO, 0);
-            if self.leaf_is_supported(EAX_TRACE_INFO) {
-                Some(ProcessorTraceInfo {
-                    eax: res.eax,
-                    ebx: res.ebx,
-                    ecx: res.ecx,
-                    edx: res.edx,
-                })
-            } else {
-                None
-            }
-        }
-
-        /// Time Stamp Counter/Core Crystal Clock Information.
-        pub fn get_tsc_info(&self) -> Option<TscInfo> {
-            let res = cpuid!(EAX_TIME_STAMP_COUNTER_INFO, 0);
-            if self.leaf_is_supported(EAX_TIME_STAMP_COUNTER_INFO) {
-                Some(TscInfo {
-                    eax: res.eax,
-                    ebx: res.ebx,
-                })
-            } else {
-                None
-            }
-        }
-
-        /// Processor Frequency Information.
-        pub fn get_processor_frequency_info(&self) -> Option<ProcessorFrequencyInfo> {
-            let res = cpuid!(EAX_FREQUENCY_INFO, 0);
-            if self.leaf_is_supported(EAX_FREQUENCY_INFO) {
-                Some(ProcessorFrequencyInfo {
-                    eax: res.eax,
-                    ebx: res.ebx,
-                    ecx: res.ecx,
-                })
-            } else {
-                None
-            }
-        }
-
-        pub fn get_soc_vendor_info(&self) -> Option<SoCVendorInfo> {
-            let res = cpuid!(EAX_SOC_VENDOR_INFO, 0);
-            if self.leaf_is_supported(EAX_SOC_VENDOR_INFO) {
-                Some(SoCVendorInfo {
-                    eax: res.eax,
-                    ebx: res.ebx,
-                    ecx: res.ecx,
-                    edx: res.edx,
-                })
-            } else {
-                None
-            }
-        }
-
-        /// Extended functionality of CPU described here (including more supported features).
-        /// This also contains a more detailed CPU model identifier.
-        pub fn get_extended_function_info(&self) -> Option<ExtendedFunctionInfo> {
-            let res = cpuid!(EAX_EXTENDED_FUNCTION_INFO);
-
-            if res.eax == 0 {
-                return None;
-            }
-
-            let mut ef = ExtendedFunctionInfo {
-                max_eax_value: res.eax - EAX_EXTENDED_FUNCTION_INFO,
-                data: [CpuIdResult {
-                    eax: res.eax,
-                    ebx: res.ebx,
-                    ecx: res.ecx,
-                    edx: res.edx,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                }],
-            };
-
-            let max_eax_value = min(ef.max_eax_value + 1, ef.data.len() as u32);
-            for i in 1..max_eax_value {
-                ef.data[i as usize] = cpuid!(EAX_EXTENDED_FUNCTION_INFO + i);
-            }
-
-            Some(ef)
+    /// Retrieve serial number of processor.
+    pub fn get_processor_serial(&self) -> Option<ProcessorSerial> {
+        if self.leaf_is_supported(EAX_PROCESSOR_SERIAL) {
+            let res = cpuid!(EAX_PROCESSOR_SERIAL);
+            Some(ProcessorSerial {
+                ecx: res.ecx,
+                edx: res.edx,
+            })
+        } else {
+            None
         }
 
     }
+
+    /// Retrieve more elaborate information about caches (as opposed
+    /// to `get_cache_info`). This will tell us about associativity,
+    /// set size, line size etc. for each level of the cache hierarchy.
+    pub fn get_cache_parameters(&self) -> Option<CacheParametersIter> {
+        if self.leaf_is_supported(EAX_CACHE_PARAMETERS) {
+            Some(CacheParametersIter { current: 0 })
+        } else {
+            None
+        }
+    }
+
+    /// Information about how monitor/mwait works on this CPU.
+    pub fn get_monitor_mwait_info(&self) -> Option<MonitorMwaitInfo> {
+        if self.leaf_is_supported(EAX_MONITOR_MWAIT_INFO) {
+            let res = cpuid!(EAX_MONITOR_MWAIT_INFO);
+            Some(MonitorMwaitInfo {
+                eax: res.eax,
+                ebx: res.ebx,
+                ecx: res.ecx,
+                edx: res.edx,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Query information about thermal and power management features of the CPU.
+    pub fn get_thermal_power_info(&self) -> Option<ThermalPowerInfo> {
+        if self.leaf_is_supported(EAX_THERMAL_POWER_INFO) {
+            let res = cpuid!(EAX_THERMAL_POWER_INFO);
+            Some(ThermalPowerInfo {
+                eax: ThermalPowerFeaturesEax { bits: res.eax },
+                ebx: res.ebx,
+                ecx: ThermalPowerFeaturesEcx { bits: res.ecx },
+                edx: res.edx,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Find out about more features supported by this CPU.
+    pub fn get_extended_feature_info(&self) -> Option<ExtendedFeatures> {
+        if self.leaf_is_supported(EAX_STRUCTURED_EXTENDED_FEATURE_INFO) {
+            let res = cpuid!(EAX_STRUCTURED_EXTENDED_FEATURE_INFO);
+            assert!(res.eax == 0);
+            Some(ExtendedFeatures {
+                eax: res.eax,
+                ebx: ExtendedFeaturesEbx { bits: res.ebx },
+                ecx: res.ecx,
+                edx: res.edx,
+            })
+        } else {
+            None
+        }
+
+    }
+
+    /// Direct cache access info.
+    pub fn get_direct_cache_access_info(&self) -> Option<DirectCacheAccessInfo> {
+        if self.leaf_is_supported(EAX_DIRECT_CACHE_ACCESS_INFO) {
+            let res = cpuid!(EAX_DIRECT_CACHE_ACCESS_INFO);
+            Some(DirectCacheAccessInfo { eax: res.eax })
+        } else {
+            None
+        }
+    }
+
+    /// Info about performance monitoring (how many counters etc.).
+    pub fn get_performance_monitoring_info(&self) -> Option<PerformanceMonitoringInfo> {
+        if self.leaf_is_supported(EAX_PERFORMANCE_MONITOR_INFO) {
+            let res = cpuid!(EAX_PERFORMANCE_MONITOR_INFO);
+            Some(PerformanceMonitoringInfo {
+                eax: res.eax,
+                ebx: PerformanceMonitoringFeaturesEbx { bits: res.ebx },
+                ecx: res.ecx,
+                edx: res.edx,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Information about topology (how many cores and what kind of cores).
+    pub fn get_extended_topology_info(&self) -> Option<ExtendedTopologyIter> {
+        if self.leaf_is_supported(EAX_EXTENDED_TOPOLOGY_INFO) {
+            Some(ExtendedTopologyIter { level: 0 })
+        } else {
+            None
+        }
+    }
+
+    /// Information for saving/restoring extended register state.
+    pub fn get_extended_state_info(&self) -> Option<ExtendedStateInfo> {
+        if self.leaf_is_supported(EAX_EXTENDED_STATE_INFO) {
+            let res = cpuid!(EAX_EXTENDED_STATE_INFO, 0);
+            let res1 = cpuid!(EAX_EXTENDED_STATE_INFO, 1);
+            Some(ExtendedStateInfo {
+                eax: res.eax,
+                ebx: res.ebx,
+                ecx: res.ecx,
+                edx: res.edx,
+                eax1: res1.eax,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Quality of service informations.
+    pub fn get_qos_info(&self) -> Option<QoSInfo> {
+        let res = cpuid!(EAX_QOS_INFO, 0);
+        let res1 = cpuid!(EAX_QOS_INFO, 1);
+
+        if self.leaf_is_supported(EAX_QOS_INFO) {
+            Some(QoSInfo {
+                ebx0: res.ebx,
+                edx0: res.edx,
+                ebx1: res1.ebx,
+                ecx1: res1.ecx,
+                edx1: res1.edx,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Quality of service enforcement information.
+    pub fn get_qos_enforcement_info(&self) -> Option<QoSEnforcementInfo> {
+        let res = cpuid!(EAX_QOS_ENFORCEMENT_INFO, 0);
+        let res1 = cpuid!(EAX_QOS_ENFORCEMENT_INFO, 1);
+
+        if self.leaf_is_supported(EAX_QOS_ENFORCEMENT_INFO) {
+            Some(QoSEnforcementInfo {
+                ebx0: res.ebx,
+                eax1: res1.eax,
+                ebx1: res1.ebx,
+                ecx1: res1.ecx,
+                edx1: res1.edx,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Intel Processor Trace Enumeration Information.
+    pub fn get_processor_trace_info(&self) -> Option<ProcessorTraceInfo> {
+        let res = cpuid!(EAX_TRACE_INFO, 0);
+        if self.leaf_is_supported(EAX_TRACE_INFO) {
+            Some(ProcessorTraceInfo {
+                eax: res.eax,
+                ebx: res.ebx,
+                ecx: res.ecx,
+                edx: res.edx,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Time Stamp Counter/Core Crystal Clock Information.
+    pub fn get_tsc_info(&self) -> Option<TscInfo> {
+        let res = cpuid!(EAX_TIME_STAMP_COUNTER_INFO, 0);
+        if self.leaf_is_supported(EAX_TIME_STAMP_COUNTER_INFO) {
+            Some(TscInfo {
+                eax: res.eax,
+                ebx: res.ebx,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Processor Frequency Information.
+    pub fn get_processor_frequency_info(&self) -> Option<ProcessorFrequencyInfo> {
+        let res = cpuid!(EAX_FREQUENCY_INFO, 0);
+        if self.leaf_is_supported(EAX_FREQUENCY_INFO) {
+            Some(ProcessorFrequencyInfo {
+                eax: res.eax,
+                ebx: res.ebx,
+                ecx: res.ecx,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn get_soc_vendor_info(&self) -> Option<SoCVendorInfo> {
+        let res = cpuid!(EAX_SOC_VENDOR_INFO, 0);
+        if self.leaf_is_supported(EAX_SOC_VENDOR_INFO) {
+            Some(SoCVendorInfo {
+                eax: res.eax,
+                ebx: res.ebx,
+                ecx: res.ecx,
+                edx: res.edx,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Extended functionality of CPU described here (including more supported features).
+    /// This also contains a more detailed CPU model identifier.
+    pub fn get_extended_function_info(&self) -> Option<ExtendedFunctionInfo> {
+        let res = cpuid!(EAX_EXTENDED_FUNCTION_INFO);
+
+        if res.eax == 0 {
+            return None;
+        }
+
+        let mut ef = ExtendedFunctionInfo {
+            max_eax_value: res.eax - EAX_EXTENDED_FUNCTION_INFO,
+            data: [CpuIdResult {
+                       eax: res.eax,
+                       ebx: res.ebx,
+                       ecx: res.ecx,
+                       edx: res.edx,
+                   },
+                   CpuIdResult {
+                       eax: 0,
+                       ebx: 0,
+                       ecx: 0,
+                       edx: 0,
+                   },
+                   CpuIdResult {
+                       eax: 0,
+                       ebx: 0,
+                       ecx: 0,
+                       edx: 0,
+                   },
+                   CpuIdResult {
+                       eax: 0,
+                       ebx: 0,
+                       ecx: 0,
+                       edx: 0,
+                   },
+                   CpuIdResult {
+                       eax: 0,
+                       ebx: 0,
+                       ecx: 0,
+                       edx: 0,
+                   },
+                   CpuIdResult {
+                       eax: 0,
+                       ebx: 0,
+                       ecx: 0,
+                       edx: 0,
+                   },
+                   CpuIdResult {
+                       eax: 0,
+                       ebx: 0,
+                       ecx: 0,
+                       edx: 0,
+                   },
+                   CpuIdResult {
+                       eax: 0,
+                       ebx: 0,
+                       ecx: 0,
+                       edx: 0,
+                   },
+                   CpuIdResult {
+                       eax: 0,
+                       ebx: 0,
+                       ecx: 0,
+                       edx: 0,
+                   }],
+        };
+
+        let max_eax_value = min(ef.max_eax_value + 1, ef.data.len() as u32);
+        for i in 1..max_eax_value {
+            ef.data[i as usize] = cpuid!(EAX_EXTENDED_FUNCTION_INFO + i);
+        }
+
+        Some(ef)
+    }
+
+}
 
 #[derive(Debug)]
 pub struct VendorInfo {
@@ -619,553 +620,553 @@ impl fmt::Display for CacheInfo {
 
 /// This table is taken from Intel manual (Section CPUID instruction).
 pub const CACHE_INFO_TABLE: [CacheInfo; 107] =
-[CacheInfo {
-    num: 0x00,
-    typ: CacheInfoType::GENERAL,
-    desc: "Null descriptor, this byte contains no information",
-},
-CacheInfo {
-    num: 0x01,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 4 KByte pages, 4-way set associative, 32 entries",
-},
-CacheInfo {
-    num: 0x02,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 4 MByte pages, fully associative, 2 entries",
-},
-CacheInfo {
-    num: 0x03,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB: 4 KByte pages, 4-way set associative, 64 entries",
-},
-CacheInfo {
-    num: 0x04,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB: 4 MByte pages, 4-way set associative, 8 entries",
-},
-CacheInfo {
-    num: 0x05,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB1: 4 MByte pages, 4-way set associative, 32 entries",
-},
-CacheInfo {
-    num: 0x06,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level instruction cache: 8 KBytes, 4-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x08,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level instruction cache: 16 KBytes, 4-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x09,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level instruction cache: 32KBytes, 4-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x0A,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level data cache: 8 KBytes, 2-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x0B,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 4 MByte pages, 4-way set associative, 4 entries",
-},
-CacheInfo {
-    num: 0x0C,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level data cache: 16 KBytes, 4-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x0D,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level data cache: 16 KBytes, 4-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x0E,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level data cache: 24 KBytes, 6-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x21,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 256 KBytes, 8-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x22,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 512 KBytes, 4-way set associative, 64 byte line size, 2 lines \
-        per sector",
-},
-CacheInfo {
-    num: 0x23,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 1 MBytes, 8-way set associative, 64 byte line size, 2 lines per \
-        sector",
-},
-CacheInfo {
-    num: 0x24,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 1 MBytes, 16-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x25,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 2 MBytes, 8-way set associative, 64 byte line size, 2 lines per \
-        sector",
-},
-CacheInfo {
-    num: 0x29,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 4 MBytes, 8-way set associative, 64 byte line size, 2 lines per \
-        sector",
-},
-CacheInfo {
-    num: 0x2C,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level data cache: 32 KBytes, 8-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x30,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level instruction cache: 32 KBytes, 8-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x40,
-    typ: CacheInfoType::CACHE,
-    desc: "No 2nd-level cache or, if processor contains a valid 2nd-level cache, no \
-        3rd-level cache",
-},
-CacheInfo {
-    num: 0x41,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 128 KBytes, 4-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x42,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 256 KBytes, 4-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x43,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 512 KBytes, 4-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x44,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 1 MByte, 4-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x45,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 2 MByte, 4-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x46,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 4 MByte, 4-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x47,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 8 MByte, 8-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x48,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 3MByte, 12-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x49,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 4MB, 16-way set associative, 64-byte line size (Intel Xeon \
-        processor MP, Family 0FH, Model 06H); 2nd-level cache: 4 MByte, 16-way set \
+    [CacheInfo {
+         num: 0x00,
+         typ: CacheInfoType::GENERAL,
+         desc: "Null descriptor, this byte contains no information",
+     },
+     CacheInfo {
+         num: 0x01,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 4 KByte pages, 4-way set associative, 32 entries",
+     },
+     CacheInfo {
+         num: 0x02,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 4 MByte pages, fully associative, 2 entries",
+     },
+     CacheInfo {
+         num: 0x03,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB: 4 KByte pages, 4-way set associative, 64 entries",
+     },
+     CacheInfo {
+         num: 0x04,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB: 4 MByte pages, 4-way set associative, 8 entries",
+     },
+     CacheInfo {
+         num: 0x05,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB1: 4 MByte pages, 4-way set associative, 32 entries",
+     },
+     CacheInfo {
+         num: 0x06,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level instruction cache: 8 KBytes, 4-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x08,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level instruction cache: 16 KBytes, 4-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x09,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level instruction cache: 32KBytes, 4-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x0A,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level data cache: 8 KBytes, 2-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x0B,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 4 MByte pages, 4-way set associative, 4 entries",
+     },
+     CacheInfo {
+         num: 0x0C,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level data cache: 16 KBytes, 4-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x0D,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level data cache: 16 KBytes, 4-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x0E,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level data cache: 24 KBytes, 6-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x21,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 256 KBytes, 8-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x22,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 512 KBytes, 4-way set associative, 64 byte line size, 2 lines \
+                per sector",
+     },
+     CacheInfo {
+         num: 0x23,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 1 MBytes, 8-way set associative, 64 byte line size, 2 lines per \
+                sector",
+     },
+     CacheInfo {
+         num: 0x24,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 1 MBytes, 16-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x25,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 2 MBytes, 8-way set associative, 64 byte line size, 2 lines per \
+                sector",
+     },
+     CacheInfo {
+         num: 0x29,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 4 MBytes, 8-way set associative, 64 byte line size, 2 lines per \
+                sector",
+     },
+     CacheInfo {
+         num: 0x2C,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level data cache: 32 KBytes, 8-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x30,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level instruction cache: 32 KBytes, 8-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x40,
+         typ: CacheInfoType::CACHE,
+         desc: "No 2nd-level cache or, if processor contains a valid 2nd-level cache, no \
+                3rd-level cache",
+     },
+     CacheInfo {
+         num: 0x41,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 128 KBytes, 4-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x42,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 256 KBytes, 4-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x43,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 512 KBytes, 4-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x44,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 1 MByte, 4-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x45,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 2 MByte, 4-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x46,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 4 MByte, 4-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x47,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 8 MByte, 8-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x48,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 3MByte, 12-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x49,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 4MB, 16-way set associative, 64-byte line size (Intel Xeon \
+                processor MP, Family 0FH, Model 06H); 2nd-level cache: 4 MByte, 16-way set \
                 associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x4A,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 6MByte, 12-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x4B,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 8MByte, 16-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x4C,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 12MByte, 12-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x4D,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 16MByte, 16-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x4E,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 6MByte, 24-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x4F,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 4 KByte pages, 32 entries",
-},
-CacheInfo {
-    num: 0x50,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 64 entries",
-},
-CacheInfo {
-    num: 0x51,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 128 entries",
-},
-CacheInfo {
-    num: 0x52,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 256 entries",
-},
-CacheInfo {
-    num: 0x55,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 2-MByte or 4-MByte pages, fully associative, 7 entries",
-},
-CacheInfo {
-    num: 0x56,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB0: 4 MByte pages, 4-way set associative, 16 entries",
-},
-CacheInfo {
-    num: 0x57,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB0: 4 KByte pages, 4-way associative, 16 entries",
-},
-CacheInfo {
-    num: 0x59,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB0: 4 KByte pages, fully associative, 16 entries",
-},
-CacheInfo {
-    num: 0x5A,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB0: 2-MByte or 4 MByte pages, 4-way set associative, 32 entries",
-},
-CacheInfo {
-    num: 0x5B,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB: 4 KByte and 4 MByte pages, 64 entries",
-},
-CacheInfo {
-    num: 0x5C,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB: 4 KByte and 4 MByte pages,128 entries",
-},
-CacheInfo {
-    num: 0x5D,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB: 4 KByte and 4 MByte pages,256 entries",
-},
-CacheInfo {
-    num: 0x60,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level data cache: 16 KByte, 8-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x61,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 4 KByte pages, fully associative, 48 entries",
-},
-CacheInfo {
-    num: 0x63,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB: 1 GByte pages, 4-way set associative, 4 entries",
-},
-CacheInfo {
-    num: 0x66,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level data cache: 8 KByte, 4-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x67,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level data cache: 16 KByte, 4-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x68,
-    typ: CacheInfoType::CACHE,
-    desc: "1st-level data cache: 32 KByte, 4-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x6A,
-    typ: CacheInfoType::CACHE,
-    desc: "uTLB: 4 KByte pages, 8-way set associative, 64 entries",
-},
-CacheInfo {
-    num: 0x6B,
-    typ: CacheInfoType::CACHE,
-    desc: "DTLB: 4 KByte pages, 8-way set associative, 256 entries",
-},
-CacheInfo {
-    num: 0x6C,
-    typ: CacheInfoType::CACHE,
-    desc: "DTLB: 2M/4M pages, 8-way set associative, 128 entries",
-},
-CacheInfo {
-    num: 0x6D,
-    typ: CacheInfoType::CACHE,
-    desc: "DTLB: 1 GByte pages, fully associative, 16 entries",
-},
-CacheInfo {
-    num: 0x70,
-    typ: CacheInfoType::CACHE,
-    desc: "Trace cache: 12 K-μop, 8-way set associative",
-},
-CacheInfo {
-    num: 0x71,
-    typ: CacheInfoType::CACHE,
-    desc: "Trace cache: 16 K-μop, 8-way set associative",
-},
-CacheInfo {
-    num: 0x72,
-    typ: CacheInfoType::CACHE,
-    desc: "Trace cache: 32 K-μop, 8-way set associative",
-},
-CacheInfo {
-    num: 0x76,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 2M/4M pages, fully associative, 8 entries",
-},
-CacheInfo {
-    num: 0x78,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 1 MByte, 4-way set associative, 64byte line size",
-},
-CacheInfo {
-    num: 0x79,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 128 KByte, 8-way set associative, 64 byte line size, 2 lines per \
-        sector",
-},
-CacheInfo {
-    num: 0x7A,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 256 KByte, 8-way set associative, 64 byte line size, 2 lines per \
-        sector",
-},
-CacheInfo {
-    num: 0x7B,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 512 KByte, 8-way set associative, 64 byte line size, 2 lines per \
-        sector",
-},
-CacheInfo {
-    num: 0x7C,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 1 MByte, 8-way set associative, 64 byte line size, 2 lines per \
-        sector",
-},
-CacheInfo {
-    num: 0x7D,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 2 MByte, 8-way set associative, 64byte line size",
-},
-CacheInfo {
-    num: 0x7F,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 512 KByte, 2-way set associative, 64-byte line size",
-},
-CacheInfo {
-    num: 0x80,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 512 KByte, 8-way set associative, 64-byte line size",
-},
-CacheInfo {
-    num: 0x82,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 256 KByte, 8-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x83,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 512 KByte, 8-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x84,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 1 MByte, 8-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x85,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 2 MByte, 8-way set associative, 32 byte line size",
-},
-CacheInfo {
-    num: 0x86,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 512 KByte, 4-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0x87,
-    typ: CacheInfoType::CACHE,
-    desc: "2nd-level cache: 1 MByte, 8-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xB0,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 4 KByte pages, 4-way set associative, 128 entries",
-},
-CacheInfo {
-    num: 0xB1,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 2M pages, 4-way, 8 entries or 4M pages, 4-way, 4 entries",
-},
-CacheInfo {
-    num: 0xB2,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 4KByte pages, 4-way set associative, 64 entries",
-},
-CacheInfo {
-    num: 0xB3,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB: 4 KByte pages, 4-way set associative, 128 entries",
-},
-CacheInfo {
-    num: 0xB4,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB1: 4 KByte pages, 4-way associative, 256 entries",
-},
-CacheInfo {
-    num: 0xB5,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 4KByte pages, 8-way set associative, 64 entries",
-},
-CacheInfo {
-    num: 0xB6,
-    typ: CacheInfoType::TLB,
-    desc: "Instruction TLB: 4KByte pages, 8-way set associative, 128 entries",
-},
-CacheInfo {
-    num: 0xBA,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB1: 4 KByte pages, 4-way associative, 64 entries",
-},
-CacheInfo {
-    num: 0xC0,
-    typ: CacheInfoType::TLB,
-    desc: "Data TLB: 4 KByte and 4 MByte pages, 4-way associative, 8 entries",
-},
-CacheInfo {
-    num: 0xC1,
-    typ: CacheInfoType::STLB,
-    desc: "Shared 2nd-Level TLB: 4 KByte/2MByte pages, 8-way associative, 1024 entries",
-},
-CacheInfo {
-    num: 0xC2,
-    typ: CacheInfoType::DTLB,
-    desc: "DTLB: 2 MByte/$MByte pages, 4-way associative, 16 entries",
-},
-CacheInfo {
-    num: 0xCA,
-    typ: CacheInfoType::STLB,
-    desc: "Shared 2nd-Level TLB: 4 KByte pages, 4-way associative, 512 entries",
-},
-CacheInfo {
-    num: 0xD0,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 512 KByte, 4-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xD1,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 1 MByte, 4-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xD2,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 2 MByte, 4-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xD6,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 1 MByte, 8-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xD7,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 2 MByte, 8-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xD8,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 4 MByte, 8-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xDC,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 1.5 MByte, 12-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xDD,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 3 MByte, 12-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xDE,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 6 MByte, 12-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xE2,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 2 MByte, 16-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xE3,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 4 MByte, 16-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xE4,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 8 MByte, 16-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xEA,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 12MByte, 24-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xEB,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 18MByte, 24-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xEC,
-    typ: CacheInfoType::CACHE,
-    desc: "3rd-level cache: 24MByte, 24-way set associative, 64 byte line size",
-},
-CacheInfo {
-    num: 0xF0,
-    typ: CacheInfoType::PREFETCH,
-    desc: "64-Byte prefetching",
-},
-CacheInfo {
-    num: 0xF1,
-    typ: CacheInfoType::PREFETCH,
-    desc: "128-Byte prefetching",
-},
-CacheInfo {
-    num: 0xFF,
-    typ: CacheInfoType::GENERAL,
-    desc: "CPUID leaf 2 does not report cache descriptor information, use CPUID leaf 4 to \
-        query cache parameters",
-}];
+     },
+     CacheInfo {
+         num: 0x4A,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 6MByte, 12-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x4B,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 8MByte, 16-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x4C,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 12MByte, 12-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x4D,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 16MByte, 16-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x4E,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 6MByte, 24-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x4F,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 4 KByte pages, 32 entries",
+     },
+     CacheInfo {
+         num: 0x50,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 64 entries",
+     },
+     CacheInfo {
+         num: 0x51,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 128 entries",
+     },
+     CacheInfo {
+         num: 0x52,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 256 entries",
+     },
+     CacheInfo {
+         num: 0x55,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 2-MByte or 4-MByte pages, fully associative, 7 entries",
+     },
+     CacheInfo {
+         num: 0x56,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB0: 4 MByte pages, 4-way set associative, 16 entries",
+     },
+     CacheInfo {
+         num: 0x57,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB0: 4 KByte pages, 4-way associative, 16 entries",
+     },
+     CacheInfo {
+         num: 0x59,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB0: 4 KByte pages, fully associative, 16 entries",
+     },
+     CacheInfo {
+         num: 0x5A,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB0: 2-MByte or 4 MByte pages, 4-way set associative, 32 entries",
+     },
+     CacheInfo {
+         num: 0x5B,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB: 4 KByte and 4 MByte pages, 64 entries",
+     },
+     CacheInfo {
+         num: 0x5C,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB: 4 KByte and 4 MByte pages,128 entries",
+     },
+     CacheInfo {
+         num: 0x5D,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB: 4 KByte and 4 MByte pages,256 entries",
+     },
+     CacheInfo {
+         num: 0x60,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level data cache: 16 KByte, 8-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x61,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 4 KByte pages, fully associative, 48 entries",
+     },
+     CacheInfo {
+         num: 0x63,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB: 1 GByte pages, 4-way set associative, 4 entries",
+     },
+     CacheInfo {
+         num: 0x66,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level data cache: 8 KByte, 4-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x67,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level data cache: 16 KByte, 4-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x68,
+         typ: CacheInfoType::CACHE,
+         desc: "1st-level data cache: 32 KByte, 4-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x6A,
+         typ: CacheInfoType::CACHE,
+         desc: "uTLB: 4 KByte pages, 8-way set associative, 64 entries",
+     },
+     CacheInfo {
+         num: 0x6B,
+         typ: CacheInfoType::CACHE,
+         desc: "DTLB: 4 KByte pages, 8-way set associative, 256 entries",
+     },
+     CacheInfo {
+         num: 0x6C,
+         typ: CacheInfoType::CACHE,
+         desc: "DTLB: 2M/4M pages, 8-way set associative, 128 entries",
+     },
+     CacheInfo {
+         num: 0x6D,
+         typ: CacheInfoType::CACHE,
+         desc: "DTLB: 1 GByte pages, fully associative, 16 entries",
+     },
+     CacheInfo {
+         num: 0x70,
+         typ: CacheInfoType::CACHE,
+         desc: "Trace cache: 12 K-μop, 8-way set associative",
+     },
+     CacheInfo {
+         num: 0x71,
+         typ: CacheInfoType::CACHE,
+         desc: "Trace cache: 16 K-μop, 8-way set associative",
+     },
+     CacheInfo {
+         num: 0x72,
+         typ: CacheInfoType::CACHE,
+         desc: "Trace cache: 32 K-μop, 8-way set associative",
+     },
+     CacheInfo {
+         num: 0x76,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 2M/4M pages, fully associative, 8 entries",
+     },
+     CacheInfo {
+         num: 0x78,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 1 MByte, 4-way set associative, 64byte line size",
+     },
+     CacheInfo {
+         num: 0x79,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 128 KByte, 8-way set associative, 64 byte line size, 2 lines per \
+                sector",
+     },
+     CacheInfo {
+         num: 0x7A,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 256 KByte, 8-way set associative, 64 byte line size, 2 lines per \
+                sector",
+     },
+     CacheInfo {
+         num: 0x7B,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 512 KByte, 8-way set associative, 64 byte line size, 2 lines per \
+                sector",
+     },
+     CacheInfo {
+         num: 0x7C,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 1 MByte, 8-way set associative, 64 byte line size, 2 lines per \
+                sector",
+     },
+     CacheInfo {
+         num: 0x7D,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 2 MByte, 8-way set associative, 64byte line size",
+     },
+     CacheInfo {
+         num: 0x7F,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 512 KByte, 2-way set associative, 64-byte line size",
+     },
+     CacheInfo {
+         num: 0x80,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 512 KByte, 8-way set associative, 64-byte line size",
+     },
+     CacheInfo {
+         num: 0x82,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 256 KByte, 8-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x83,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 512 KByte, 8-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x84,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 1 MByte, 8-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x85,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 2 MByte, 8-way set associative, 32 byte line size",
+     },
+     CacheInfo {
+         num: 0x86,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 512 KByte, 4-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0x87,
+         typ: CacheInfoType::CACHE,
+         desc: "2nd-level cache: 1 MByte, 8-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xB0,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 4 KByte pages, 4-way set associative, 128 entries",
+     },
+     CacheInfo {
+         num: 0xB1,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 2M pages, 4-way, 8 entries or 4M pages, 4-way, 4 entries",
+     },
+     CacheInfo {
+         num: 0xB2,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 4KByte pages, 4-way set associative, 64 entries",
+     },
+     CacheInfo {
+         num: 0xB3,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB: 4 KByte pages, 4-way set associative, 128 entries",
+     },
+     CacheInfo {
+         num: 0xB4,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB1: 4 KByte pages, 4-way associative, 256 entries",
+     },
+     CacheInfo {
+         num: 0xB5,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 4KByte pages, 8-way set associative, 64 entries",
+     },
+     CacheInfo {
+         num: 0xB6,
+         typ: CacheInfoType::TLB,
+         desc: "Instruction TLB: 4KByte pages, 8-way set associative, 128 entries",
+     },
+     CacheInfo {
+         num: 0xBA,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB1: 4 KByte pages, 4-way associative, 64 entries",
+     },
+     CacheInfo {
+         num: 0xC0,
+         typ: CacheInfoType::TLB,
+         desc: "Data TLB: 4 KByte and 4 MByte pages, 4-way associative, 8 entries",
+     },
+     CacheInfo {
+         num: 0xC1,
+         typ: CacheInfoType::STLB,
+         desc: "Shared 2nd-Level TLB: 4 KByte/2MByte pages, 8-way associative, 1024 entries",
+     },
+     CacheInfo {
+         num: 0xC2,
+         typ: CacheInfoType::DTLB,
+         desc: "DTLB: 2 MByte/$MByte pages, 4-way associative, 16 entries",
+     },
+     CacheInfo {
+         num: 0xCA,
+         typ: CacheInfoType::STLB,
+         desc: "Shared 2nd-Level TLB: 4 KByte pages, 4-way associative, 512 entries",
+     },
+     CacheInfo {
+         num: 0xD0,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 512 KByte, 4-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xD1,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 1 MByte, 4-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xD2,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 2 MByte, 4-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xD6,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 1 MByte, 8-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xD7,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 2 MByte, 8-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xD8,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 4 MByte, 8-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xDC,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 1.5 MByte, 12-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xDD,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 3 MByte, 12-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xDE,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 6 MByte, 12-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xE2,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 2 MByte, 16-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xE3,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 4 MByte, 16-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xE4,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 8 MByte, 16-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xEA,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 12MByte, 24-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xEB,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 18MByte, 24-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xEC,
+         typ: CacheInfoType::CACHE,
+         desc: "3rd-level cache: 24MByte, 24-way set associative, 64 byte line size",
+     },
+     CacheInfo {
+         num: 0xF0,
+         typ: CacheInfoType::PREFETCH,
+         desc: "64-Byte prefetching",
+     },
+     CacheInfo {
+         num: 0xF1,
+         typ: CacheInfoType::PREFETCH,
+         desc: "128-Byte prefetching",
+     },
+     CacheInfo {
+         num: 0xFF,
+         typ: CacheInfoType::GENERAL,
+         desc: "CPUID leaf 2 does not report cache descriptor information, use CPUID leaf 4 to \
+                query cache parameters",
+     }];
 
 impl fmt::Display for VendorInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1247,21 +1248,21 @@ impl FeatureInfo {
 
     check_flag!(doc = "Streaming SIMD Extensions 3 (SSE3). A value of 1 indicates the processor \
                        supports this technology.",
-                       has_sse3,
-                       edx_ecx,
-                       CPU_FEATURE_SSE3);
+                has_sse3,
+                edx_ecx,
+                CPU_FEATURE_SSE3);
 
     check_flag!(doc = "PCLMULQDQ. A value of 1 indicates the processor supports the PCLMULQDQ \
                        instruction",
-                       has_pclmulqdq,
-                       edx_ecx,
-                       CPU_FEATURE_PCLMULQDQ);
+                has_pclmulqdq,
+                edx_ecx,
+                CPU_FEATURE_PCLMULQDQ);
 
     check_flag!(doc = "64-bit DS Area. A value of 1 indicates the processor supports DS area \
                        using 64-bit layout",
-                       has_ds_area,
-                       edx_ecx,
-                       CPU_FEATURE_DTES64);
+                has_ds_area,
+                edx_ecx,
+                CPU_FEATURE_DTES64);
 
     check_flag!(doc = "MONITOR/MWAIT. A value of 1 indicates the processor supports this feature.",
                 has_monitor_mwait,
@@ -1271,80 +1272,80 @@ impl FeatureInfo {
     check_flag!(doc = "CPL Qualified Debug Store. A value of 1 indicates the processor supports \
                        the extensions to the  Debug Store feature to allow for branch message \
                        storage qualified by CPL.",
-                       has_cpl,
-                       edx_ecx,
-                       CPU_FEATURE_DSCPL);
+                has_cpl,
+                edx_ecx,
+                CPU_FEATURE_DSCPL);
 
     check_flag!(doc = "Virtual Machine Extensions. A value of 1 indicates that the processor \
                        supports this technology.",
-                       has_vmx,
-                       edx_ecx,
-                       CPU_FEATURE_VMX);
+                has_vmx,
+                edx_ecx,
+                CPU_FEATURE_VMX);
 
     check_flag!(doc = "Safer Mode Extensions. A value of 1 indicates that the processor supports \
                        this technology. See Chapter 5, Safer Mode Extensions Reference.",
-                       has_smx,
-                       edx_ecx,
-                       CPU_FEATURE_SMX);
+                has_smx,
+                edx_ecx,
+                CPU_FEATURE_SMX);
 
     check_flag!(doc = "Enhanced Intel SpeedStep® technology. A value of 1 indicates that the \
                        processor supports this technology.",
-                       has_eist,
-                       edx_ecx,
-                       CPU_FEATURE_EIST);
+                has_eist,
+                edx_ecx,
+                CPU_FEATURE_EIST);
 
     check_flag!(doc = "Thermal Monitor 2. A value of 1 indicates whether the processor supports \
                        this technology.",
-                       has_tm2,
-                       edx_ecx,
-                       CPU_FEATURE_TM2);
+                has_tm2,
+                edx_ecx,
+                CPU_FEATURE_TM2);
 
     check_flag!(doc = "A value of 1 indicates the presence of the Supplemental Streaming SIMD \
                        Extensions 3 (SSSE3). A value of 0 indicates the instruction extensions \
                        are not present in the processor",
-                       has_ssse3,
-                       edx_ecx,
-                       CPU_FEATURE_SSSE3);
+                has_ssse3,
+                edx_ecx,
+                CPU_FEATURE_SSSE3);
 
     check_flag!(doc = "L1 Context ID. A value of 1 indicates the L1 data cache mode can be set \
                        to either adaptive mode or shared mode. A value of 0 indicates this \
                        feature is not supported. See definition of the IA32_MISC_ENABLE MSR Bit \
                        24 (L1 Data Cache Context Mode) for details.",
-                       has_cnxtid,
-                       edx_ecx,
-                       CPU_FEATURE_CNXTID);
+                has_cnxtid,
+                edx_ecx,
+                CPU_FEATURE_CNXTID);
 
     check_flag!(doc = "A value of 1 indicates the processor supports FMA extensions using YMM \
                        state.",
-                       has_fma,
-                       edx_ecx,
-                       CPU_FEATURE_FMA);
+                has_fma,
+                edx_ecx,
+                CPU_FEATURE_FMA);
 
     check_flag!(doc = "CMPXCHG16B Available. A value of 1 indicates that the feature is \
                        available. See the CMPXCHG8B/CMPXCHG16B Compare and Exchange Bytes \
                        section. 14",
-                       has_cmpxchg16b,
-                       edx_ecx,
-                       CPU_FEATURE_CMPXCHG16B);
+                has_cmpxchg16b,
+                edx_ecx,
+                CPU_FEATURE_CMPXCHG16B);
 
     check_flag!(doc = "Perfmon and Debug Capability: A value of 1 indicates the processor \
                        supports the performance   and debug feature indication MSR \
                        IA32_PERF_CAPABILITIES.",
-                       has_pdcm,
-                       edx_ecx,
-                       CPU_FEATURE_PDCM);
+                has_pdcm,
+                edx_ecx,
+                CPU_FEATURE_PDCM);
 
     check_flag!(doc = "Process-context identifiers. A value of 1 indicates that the processor \
                        supports PCIDs and the software may set CR4.PCIDE to 1.",
-                       has_pcid,
-                       edx_ecx,
-                       CPU_FEATURE_PCID);
+                has_pcid,
+                edx_ecx,
+                CPU_FEATURE_PCID);
 
     check_flag!(doc = "A value of 1 indicates the processor supports the ability to prefetch \
                        data from a memory mapped device.",
-                       has_dca,
-                       edx_ecx,
-                       CPU_FEATURE_DCA);
+                has_dca,
+                edx_ecx,
+                CPU_FEATURE_DCA);
 
     check_flag!(doc = "A value of 1 indicates that the processor supports SSE4.1.",
                 has_sse41,
@@ -1373,41 +1374,41 @@ impl FeatureInfo {
 
     check_flag!(doc = "A value of 1 indicates that the processors local APIC timer supports \
                        one-shot operation using a TSC deadline value.",
-                       has_tsc_deadline,
-                       edx_ecx,
-                       CPU_FEATURE_TSC_DEADLINE);
+                has_tsc_deadline,
+                edx_ecx,
+                CPU_FEATURE_TSC_DEADLINE);
 
     check_flag!(doc = "A value of 1 indicates that the processor supports the AESNI instruction \
                        extensions.",
-                       has_aesni,
-                       edx_ecx,
-                       CPU_FEATURE_AESNI);
+                has_aesni,
+                edx_ecx,
+                CPU_FEATURE_AESNI);
 
     check_flag!(doc = "A value of 1 indicates that the processor supports the XSAVE/XRSTOR \
                        processor extended states feature, the XSETBV/XGETBV instructions, and \
                        XCR0.",
-                       has_xsave,
-                       edx_ecx,
-                       CPU_FEATURE_XSAVE);
+                has_xsave,
+                edx_ecx,
+                CPU_FEATURE_XSAVE);
 
     check_flag!(doc = "A value of 1 indicates that the OS has enabled XSETBV/XGETBV instructions \
                        to access XCR0, and support for processor extended state management using \
                        XSAVE/XRSTOR.",
-                       has_oxsave,
-                       edx_ecx,
-                       CPU_FEATURE_OSXSAVE);
+                has_oxsave,
+                edx_ecx,
+                CPU_FEATURE_OSXSAVE);
 
     check_flag!(doc = "A value of 1 indicates the processor supports the AVX instruction \
                        extensions.",
-                       has_avx,
-                       edx_ecx,
-                       CPU_FEATURE_AVX);
+                has_avx,
+                edx_ecx,
+                CPU_FEATURE_AVX);
 
     check_flag!(doc = "A value of 1 indicates that processor supports 16-bit floating-point \
                        conversion instructions.",
-                       has_f16c,
-                       edx_ecx,
-                       CPU_FEATURE_F16C);
+                has_f16c,
+                edx_ecx,
+                CPU_FEATURE_F16C);
 
     check_flag!(doc = "A value of 1 indicates that processor supports RDRAND instruction.",
                 has_rdrand,
@@ -1423,43 +1424,43 @@ impl FeatureInfo {
                        CR4.VME for controlling the feature, CR4.PVI for protected mode virtual \
                        interrupts, software interrupt indirection, expansion of the TSS with the \
                        software indirection bitmap, and EFLAGS.VIF and EFLAGS.VIP flags.",
-                       has_vme,
-                       edx_ecx,
-                       CPU_FEATURE_VME);
+                has_vme,
+                edx_ecx,
+                CPU_FEATURE_VME);
 
     check_flag!(doc = "Debugging Extensions. Support for I/O breakpoints, including CR4.DE for \
                        controlling the feature, and optional trapping of accesses to DR4 and DR5.",
-                       has_de,
-                       edx_ecx,
-                       CPU_FEATURE_DE);
+                has_de,
+                edx_ecx,
+                CPU_FEATURE_DE);
 
     check_flag!(doc = "Page Size Extension. Large pages of size 4 MByte are supported, including \
                        CR4.PSE for controlling the feature, the defined dirty bit in PDE (Page \
-                                                                                          Directory Entries), optional reserved bit trapping in CR3, PDEs, and PTEs.",
-                                                                                          has_pse,
-                                                                                          edx_ecx,
-                                                                                          CPU_FEATURE_PSE);
+                       Directory Entries), optional reserved bit trapping in CR3, PDEs, and PTEs.",
+                has_pse,
+                edx_ecx,
+                CPU_FEATURE_PSE);
 
     check_flag!(doc = "Time Stamp Counter. The RDTSC instruction is supported, including CR4.TSD \
                        for controlling privilege.",
-                       has_tsc,
-                       edx_ecx,
-                       CPU_FEATURE_TSC);
+                has_tsc,
+                edx_ecx,
+                CPU_FEATURE_TSC);
 
     check_flag!(doc = "Model Specific Registers RDMSR and WRMSR Instructions. The RDMSR and \
                        WRMSR instructions are supported. Some of the MSRs are implementation \
                        dependent.",
-                       has_msr,
-                       edx_ecx,
-                       CPU_FEATURE_MSR);
+                has_msr,
+                edx_ecx,
+                CPU_FEATURE_MSR);
 
     check_flag!(doc = "Physical Address Extension. Physical addresses greater than 32 bits are \
                        supported: extended page table entry formats, an extra level in the page \
                        translation tables is defined, 2-MByte pages are supported instead of 4 \
                        Mbyte pages if PAE bit is 1.",
-                       has_pae,
-                       edx_ecx,
-                       CPU_FEATURE_PAE);
+                has_pae,
+                edx_ecx,
+                CPU_FEATURE_PAE);
 
     check_flag!(doc = "Machine Check Exception. Exception 18 is defined for Machine Checks, \
                        including CR4.MCE for controlling the feature. This feature does not \
@@ -1467,82 +1468,82 @@ impl FeatureInfo {
                        reporting, and processor shutdowns. Machine Check exception handlers may \
                        have to depend on processor version to do model specific processing of \
                        the exception, or test for the presence of the Machine Check feature.",
-                       has_mce,
-                       edx_ecx,
-                       CPU_FEATURE_MCE);
+                has_mce,
+                edx_ecx,
+                CPU_FEATURE_MCE);
 
     check_flag!(doc = "CMPXCHG8B Instruction. The compare-and-exchange 8 bytes (64 bits) \
                        instruction is supported (implicitly locked and atomic).",
-                       has_cmpxchg8b,
-                       edx_ecx,
-                       CPU_FEATURE_CX8);
+                has_cmpxchg8b,
+                edx_ecx,
+                CPU_FEATURE_CX8);
 
     check_flag!(doc = "APIC On-Chip. The processor contains an Advanced Programmable Interrupt \
                        Controller (APIC), responding to memory mapped commands in the physical \
                        address range FFFE0000H to FFFE0FFFH (by default - some processors permit \
                        the APIC to be relocated).",
-                       has_apic,
-                       edx_ecx,
-                       CPU_FEATURE_APIC);
+                has_apic,
+                edx_ecx,
+                CPU_FEATURE_APIC);
 
     check_flag!(doc = "SYSENTER and SYSEXIT Instructions. The SYSENTER and SYSEXIT and \
                        associated MSRs are supported.",
-                       has_sysenter_sysexit,
-                       edx_ecx,
-                       CPU_FEATURE_SEP);
+                has_sysenter_sysexit,
+                edx_ecx,
+                CPU_FEATURE_SEP);
 
     check_flag!(doc = "Memory Type Range Registers. MTRRs are supported. The MTRRcap MSR \
                        contains feature bits that describe what memory types are supported, how \
                        many variable MTRRs are supported, and whether fixed MTRRs are supported.",
-                       has_mtrr,
-                       edx_ecx,
-                       CPU_FEATURE_MTRR);
+                has_mtrr,
+                edx_ecx,
+                CPU_FEATURE_MTRR);
 
     check_flag!(doc = "Page Global Bit. The global bit is supported in paging-structure entries \
                        that map a page, indicating TLB entries that are common to different \
                        processes and need not be flushed. The CR4.PGE bit controls this feature.",
-                       has_pge,
-                       edx_ecx,
-                       CPU_FEATURE_PGE);
+                has_pge,
+                edx_ecx,
+                CPU_FEATURE_PGE);
 
     check_flag!(doc = "Machine Check Architecture. The Machine Check Architecture, which \
                        provides a compatible mechanism for error reporting in P6 family, Pentium \
                        4, Intel Xeon processors, and future processors, is supported. The \
                        MCG_CAP MSR contains feature bits describing how many banks of error \
                        reporting MSRs are supported.",
-                       has_mca,
-                       edx_ecx,
-                       CPU_FEATURE_MCA);
+                has_mca,
+                edx_ecx,
+                CPU_FEATURE_MCA);
 
     check_flag!(doc = "Conditional Move Instructions. The conditional move instruction CMOV is \
                        supported. In addition, if x87 FPU is present as indicated by the \
                        CPUID.FPU feature bit, then the FCOMI and FCMOV instructions are supported",
-                       has_cmov,
-                       edx_ecx,
-                       CPU_FEATURE_CMOV);
+                has_cmov,
+                edx_ecx,
+                CPU_FEATURE_CMOV);
 
     check_flag!(doc = "Page Attribute Table. Page Attribute Table is supported. This feature \
                        augments the Memory Type Range Registers (MTRRs), allowing an operating \
                        system to specify attributes of memory accessed through a linear address \
                        on a 4KB granularity.",
-                       has_pat,
-                       edx_ecx,
-                       CPU_FEATURE_PAT);
+                has_pat,
+                edx_ecx,
+                CPU_FEATURE_PAT);
 
     check_flag!(doc = "36-Bit Page Size Extension. 4-MByte pages addressing physical memory \
                        beyond 4 GBytes are supported with 32-bit paging. This feature indicates \
                        that upper bits of the physical address of a 4-MByte page are encoded in \
                        bits 20:13 of the page-directory entry. Such physical addresses are \
                        limited by MAXPHYADDR and may be up to 40 bits in size.",
-                       has_pse36,
-                       edx_ecx,
-                       CPU_FEATURE_PSE36);
+                has_pse36,
+                edx_ecx,
+                CPU_FEATURE_PSE36);
 
     check_flag!(doc = "Processor Serial Number. The processor supports the 96-bit processor \
                        identification number feature and the feature is enabled.",
-                       has_psn,
-                       edx_ecx,
-                       CPU_FEATURE_PSN);
+                has_psn,
+                edx_ecx,
+                CPU_FEATURE_PSN);
 
     check_flag!(doc = "CLFLUSH Instruction. CLFLUSH Instruction is supported.",
                 has_clflush,
@@ -1553,19 +1554,19 @@ impl FeatureInfo {
                        information into a memory resident buffer. This feature is used by the \
                        branch trace store (BTS) and precise event-based sampling (PEBS) \
                        facilities (see Chapter 23, Introduction to Virtual-Machine Extensions, \
-                                   in the Intel® 64 and IA-32 Architectures Software Developers Manual, \
+                       in the Intel® 64 and IA-32 Architectures Software Developers Manual, \
                        Volume 3C).",
-                       has_ds,
-                       edx_ecx,
-                       CPU_FEATURE_DS);
+                has_ds,
+                edx_ecx,
+                CPU_FEATURE_DS);
 
     check_flag!(doc = "Thermal Monitor and Software Controlled Clock Facilities. The processor \
                        implements internal MSRs that allow processor temperature to be monitored \
                        and processor performance to be modulated in predefined duty cycles under \
                        software control.",
-                       has_acpi,
-                       edx_ecx,
-                       CPU_FEATURE_ACPI);
+                has_acpi,
+                edx_ecx,
+                CPU_FEATURE_ACPI);
 
     check_flag!(doc = "Intel MMX Technology. The processor supports the Intel MMX technology.",
                 has_mmx,
@@ -1577,9 +1578,9 @@ impl FeatureInfo {
                        Presence of this bit also indicates that CR4.OSFXSR is available for an \
                        operating system to indicate that it supports the FXSAVE and FXRSTOR \
                        instructions.",
-                       has_fxsave_fxstor,
-                       edx_ecx,
-                       CPU_FEATURE_FXSR);
+                has_fxsave_fxstor,
+                edx_ecx,
+                CPU_FEATURE_FXSR);
 
     check_flag!(doc = "SSE. The processor supports the SSE extensions.",
                 has_sse,
@@ -1594,34 +1595,34 @@ impl FeatureInfo {
     check_flag!(doc = "Self Snoop. The processor supports the management of conflicting memory \
                        types by performing a snoop of its own cache structure for transactions \
                        issued to the bus.",
-                       has_ss,
-                       edx_ecx,
-                       CPU_FEATURE_SS);
+                has_ss,
+                edx_ecx,
+                CPU_FEATURE_SS);
 
     check_flag!(doc = "Max APIC IDs reserved field is Valid. A value of 0 for HTT indicates \
                        there is only a single logical processor in the package and software \
                        should assume only a single APIC ID is reserved.  A value of 1 for HTT \
                        indicates the value in CPUID.1.EBX[23:16] (the Maximum number of \
-                                                                  addressable IDs for logical processors in this package) is valid for the \
+                       addressable IDs for logical processors in this package) is valid for the \
                        package.",
-                       has_htt,
-                       edx_ecx,
-                       CPU_FEATURE_HTT);
+                has_htt,
+                edx_ecx,
+                CPU_FEATURE_HTT);
 
     check_flag!(doc = "Thermal Monitor. The processor implements the thermal monitor automatic \
                        thermal control circuitry (TCC).",
-                       has_tm,
-                       edx_ecx,
-                       CPU_FEATURE_TM);
+                has_tm,
+                edx_ecx,
+                CPU_FEATURE_TM);
 
     check_flag!(doc = "Pending Break Enable. The processor supports the use of the FERR#/PBE# \
                        pin when the processor is in the stop-clock state (STPCLK# is asserted) \
                        to signal the processor that an interrupt is pending and that the \
                        processor should return to normal operation to handle the interrupt. Bit \
                        10 (PBE enable) in the IA32_MISC_ENABLE MSR enables this capability.",
-                       has_pbe,
-                       edx_ecx,
-                       CPU_FEATURE_PBE);
+                has_pbe,
+                edx_ecx,
+                CPU_FEATURE_PBE);
 }
 
 bitflags! {
@@ -1751,9 +1752,9 @@ bitflags! {
     }
 }
 
-        pub struct CacheParametersIter {
-            current: u32,
-        }
+pub struct CacheParametersIter {
+    current: u32,
+}
 
 impl Iterator for CacheParametersIter {
     type Item = CacheParameter;
@@ -1966,9 +1967,9 @@ impl ThermalPowerInfo {
 
     check_flag!(doc = "Intel Turbo Boost Technology Available (see description of \
                        IA32_MISC_ENABLE[38]).",
-                       has_turbo_boost,
-                       eax,
-                       CPU_FEATURE_TURBO_BOOST);
+                has_turbo_boost,
+                eax,
+                CPU_FEATURE_TURBO_BOOST);
 
     check_flag!(doc = "ARAT. APIC-Timer-always-running feature is supported if set.",
                 has_arat,
@@ -1995,16 +1996,16 @@ impl ThermalPowerInfo {
                        performance (since last reset of the counters), as a percentage of \
                        expected processor performance at frequency specified in CPUID Brand \
                        String Bits 02 - 01",
-                       has_hw_coord_feedback,
-                       ecx,
-                       CPU_FEATURE_HW_COORD_FEEDBACK);
+                has_hw_coord_feedback,
+                ecx,
+                CPU_FEATURE_HW_COORD_FEEDBACK);
 
     check_flag!(doc = "The processor supports performance-energy bias preference if \
                        CPUID.06H:ECX.SETBH[bit 3] is set and it also implies the presence of a \
                        new architectural MSR called IA32_ENERGY_PERF_BIAS (1B0H)",
-                       has_energy_bias_pref,
-                       ecx,
-                       CPU_FEATURE_ENERGY_BIAS_PREF);
+                has_energy_bias_pref,
+                ecx,
+                CPU_FEATURE_ENERGY_BIAS_PREF);
 }
 
 bitflags! {
@@ -2024,15 +2025,15 @@ bitflags! {
     }
 }
 
-        bitflags! {
-            flags ThermalPowerFeaturesEcx: u32 {
-                /// Hardware Coordination Feedback Capability (Presence of IA32_MPERF and IA32_APERF). The capability to provide a measure of delivered processor performance (since last reset of the counters), as a percentage of expected processor performance at frequency specified in CPUID Brand String Bits 02 - 01
-                const CPU_FEATURE_HW_COORD_FEEDBACK = 1 << 0,
+bitflags! {
+    flags ThermalPowerFeaturesEcx: u32 {
+        /// Hardware Coordination Feedback Capability (Presence of IA32_MPERF and IA32_APERF). The capability to provide a measure of delivered processor performance (since last reset of the counters), as a percentage of expected processor performance at frequency specified in CPUID Brand String Bits 02 - 01
+        const CPU_FEATURE_HW_COORD_FEEDBACK = 1 << 0,
 
-                /// The processor supports performance-energy bias preference if CPUID.06H:ECX.SETBH[bit 3] is set and it also implies the presence of a new architectural MSR called IA32_ENERGY_PERF_BIAS (1B0H)
-                const CPU_FEATURE_ENERGY_BIAS_PREF = 1 << 3,
-            }
-        }
+        /// The processor supports performance-energy bias preference if CPUID.06H:ECX.SETBH[bit 3] is set and it also implies the presence of a new architectural MSR called IA32_ENERGY_PERF_BIAS (1B0H)
+        const CPU_FEATURE_ENERGY_BIAS_PREF = 1 << 3,
+    }
+}
 
 impl ThermalPowerInfo {
     /// Number of Interrupt Thresholds in Digital Thermal Sensor
@@ -2085,16 +2086,16 @@ impl ExtendedFeatures {
 
     check_flag!(doc = "INVPCID. If 1, supports INVPCID instruction for system software that \
                        manages process-context identifiers.",
-                       has_invpcid,
-                       ebx,
-                       CPU_FEATURE_INVPCID);
+                has_invpcid,
+                ebx,
+                CPU_FEATURE_INVPCID);
 
     check_flag!(doc = "RTM", has_rtm, ebx, CPU_FEATURE_RTM);
 
     check_flag!(doc = "Supports Quality of Service Monitoring (QM) capability if 1.",
-    has_qm,
-    ebx,
-    CPU_FEATURE_QM);
+                has_qm,
+                ebx,
+                CPU_FEATURE_QM);
 
     check_flag!(doc = "Deprecates FPU CS and FPU DS values if 1.",
                 has_fpu_cs_ds_deprecated,
@@ -2107,9 +2108,9 @@ impl ExtendedFeatures {
                 CPU_FEATURE_MPX);
 
     check_flag!(doc = "Supports Platform Quality of Service Enforcement (PQE) capability if 1.",
-    has_pqe,
-    ebx,
-    CPU_FEATURE_PQE);
+                has_pqe,
+                ebx,
+                CPU_FEATURE_PQE);
 
     check_flag!(doc = "Supports RDSEED.",
                 has_rdseet,
@@ -2122,9 +2123,9 @@ impl ExtendedFeatures {
                 CPU_FEATURE_ADX);
 
     check_flag!(doc = "SMAP. Supports Supervisor-Mode Access Prevention (and the CLAC/STAC instructions) if 1.",
-    has_smap,
-    ebx,
-    CPU_FEATURE_SMAP);
+                has_smap,
+                ebx,
+                CPU_FEATURE_SMAP);
 
     check_flag!(doc = "Supports CLFLUSHOPT.",
                 has_clflushopt,
@@ -2184,7 +2185,7 @@ bitflags! {
     }
 }
 
-        #[derive(Debug)]
+#[derive(Debug)]
 pub struct DirectCacheAccessInfo {
     eax: u32,
 }
@@ -2292,7 +2293,7 @@ bitflags! {
     }
 }
 
-        #[derive(Debug)]
+#[derive(Debug)]
 pub struct ExtendedTopologyIter {
     level: u32,
 }
@@ -2393,7 +2394,7 @@ enum ExtendedStateIdent {
     PKRU = 1 << 9,
 }
 
-    #[derive(Debug)]
+#[derive(Debug)]
 pub struct ExtendedStateInfo {
     eax: u32,
     ebx: u32,
@@ -2408,7 +2409,7 @@ macro_rules! check_xcr_flag {
         pub fn $fun(&self) -> bool {
             self.xcr0_supported() & (ExtendedStateIdent::$flag as u64) > 0
         }
-        )
+    )
 }
 
 impl ExtendedStateInfo {
@@ -2693,37 +2694,37 @@ impl ProcessorTraceInfo {
     // EBX features
     check_bit_fn!(doc = "If true, Indicates that IA32_RTIT_CTL.CR3Filter can be set to 1, and \
                          that IA32_RTIT_CR3_MATCH MSR can be accessed.",
-                         has_rtit_cr3_match,
-                         ebx,
-                         0);
+                  has_rtit_cr3_match,
+                  ebx,
+                  0);
     check_bit_fn!(doc = "If true, Indicates support of Configurable PSB and Cycle-Accurate Mode.",
                   has_configurable_psb_and_cycle_accurate_mode,
                   ebx,
                   1);
     check_bit_fn!(doc = "If true, Indicates support of IP Filtering, TraceStop filtering, and \
                          preservation of Intel PT MSRs across warm reset.",
-                         has_ip_tracestop_filtering,
-                         ebx,
-                         2);
+                  has_ip_tracestop_filtering,
+                  ebx,
+                  2);
     check_bit_fn!(doc = "If true, Indicates support of MTC timing packet and suppression of \
                          COFI-based packets.",
-                         has_mtc_timing_packet_coefi_suppression,
-                         ebx,
-                         3);
+                  has_mtc_timing_packet_coefi_suppression,
+                  ebx,
+                  3);
 
     // ECX features
     check_bit_fn!(doc = "If true, Tracing can be enabled with IA32_RTIT_CTL.ToPA = 1, hence \
                          utilizing the ToPA output scheme; IA32_RTIT_OUTPUT_BASE and \
                          IA32_RTIT_OUTPUT_MASK_PTRS MSRs can be accessed.",
-                         has_topa,
-                         ecx,
-                         0);
+                  has_topa,
+                  ecx,
+                  0);
     check_bit_fn!(doc = "If true, ToPA tables can hold any number of output entries, up to the \
                          maximum allowed by the MaskOrTableOffset field of \
                          IA32_RTIT_OUTPUT_MASK_PTRS.",
-                         has_topa_maximum_entries,
-                         ecx,
-                         1);
+                  has_topa_maximum_entries,
+                  ecx,
+                  1);
     check_bit_fn!(doc = "If true, Indicates support of Single-Range Output scheme.",
                   has_single_range_output_scheme,
                   ecx,
@@ -2734,9 +2735,9 @@ impl ProcessorTraceInfo {
                   3);
     check_bit_fn!(doc = "If true, Generated packets which contain IP payloads have LIP values, \
                          which include the CS base component.",
-                         has_lip_with_cs_base,
-                         ecx,
-                         31);
+                  has_lip_with_cs_base,
+                  ecx,
+                  31);
 
     /// Iterator over processor trace info sub-leafs.
     pub fn iter(&self) -> ProcessorTraceIter {
@@ -2960,7 +2961,13 @@ impl ExtendedFunctionInfo {
         if self.leaf_is_supported(EAX_EXTENDED_BRAND_STRING) {
             Some(unsafe {
                 let brand_string_start = transmute::<&CpuIdResult, *const u8>(&self.data[2]);
-                let slice = slice::from_raw_parts(brand_string_start, 3 * 4 * 4);
+                let mut slice = slice::from_raw_parts(brand_string_start, 3 * 4 * 4);
+
+                match slice.iter().position(|&x| x == 0) {
+                    Some(index) => slice = slice::from_raw_parts(brand_string_start, index),
+                    None => (),
+                }
+
                 let byte_array: &'static [u8] = transmute(slice);
                 str::from_utf8_unchecked(byte_array)
             })
@@ -3040,49 +3047,49 @@ impl ExtendedFunctionInfo {
     /// Is LAHF/SAHF available in 64-bit mode?
     pub fn has_lahf_sahf(&self) -> bool {
         self.leaf_is_supported(1) &&
-            ExtendedFunctionInfoEcx { bits: self.data[1].ecx }.contains(CPU_FEATURE_LAHF_SAHF)
+        ExtendedFunctionInfoEcx { bits: self.data[1].ecx }.contains(CPU_FEATURE_LAHF_SAHF)
     }
 
     /// Is LZCNT available?
     pub fn has_lzcnt(&self) -> bool {
         self.leaf_is_supported(1) &&
-            ExtendedFunctionInfoEcx { bits: self.data[1].ecx }.contains(CPU_FEATURE_LZCNT)
+        ExtendedFunctionInfoEcx { bits: self.data[1].ecx }.contains(CPU_FEATURE_LZCNT)
     }
 
     /// Is PREFETCHW available?
     pub fn has_prefetchw(&self) -> bool {
         self.leaf_is_supported(1) &&
-            ExtendedFunctionInfoEcx { bits: self.data[1].ecx }.contains(CPU_FEATURE_PREFETCHW)
+        ExtendedFunctionInfoEcx { bits: self.data[1].ecx }.contains(CPU_FEATURE_PREFETCHW)
     }
 
     /// Are fast system calls available.
     pub fn has_syscall_sysret(&self) -> bool {
         self.leaf_is_supported(1) &&
-            ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_SYSCALL_SYSRET)
+        ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_SYSCALL_SYSRET)
     }
 
     /// Is there support for execute disable bit.
     pub fn has_execute_disable(&self) -> bool {
         self.leaf_is_supported(1) &&
-            ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_EXECUTE_DISABLE)
+        ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_EXECUTE_DISABLE)
     }
 
     /// Is there support for 1GiB pages.
     pub fn has_1gib_pages(&self) -> bool {
         self.leaf_is_supported(1) &&
-            ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_1GIB_PAGES)
+        ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_1GIB_PAGES)
     }
 
     /// Check support for rdtscp instruction.
     pub fn has_rdtscp(&self) -> bool {
         self.leaf_is_supported(1) &&
-            ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_RDTSCP)
+        ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_RDTSCP)
     }
 
     /// Check support for 64-bit mode.
     pub fn has_64bit_mode(&self) -> bool {
         self.leaf_is_supported(1) &&
-            ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_64BIT_MODE)
+        ExtendedFunctionInfoEdx { bits: self.data[1].edx }.contains(CPU_FEATURE_64BIT_MODE)
     }
 }
 
@@ -3097,20 +3104,20 @@ bitflags! {
     }
 }
 
-        bitflags! {
-            flags ExtendedFunctionInfoEdx: u32 {
-                /// SYSCALL/SYSRET available in 64-bit mode (Bit 11).
-                const CPU_FEATURE_SYSCALL_SYSRET = 1 << 11,
-                /// Execute Disable Bit available (Bit 20).
-                const CPU_FEATURE_EXECUTE_DISABLE = 1 << 20,
-                /// 1-GByte pages are available if 1 (Bit 26).
-                const CPU_FEATURE_1GIB_PAGES = 1 << 26,
-                /// RDTSCP and IA32_TSC_AUX are available if 1 (Bit 27).
-                const CPU_FEATURE_RDTSCP = 1 << 27,
-                /// Intel ® 64 Architecture available if 1 (Bit 29).
-                const CPU_FEATURE_64BIT_MODE = 1 << 29,
-            }
-        }
+bitflags! {
+    flags ExtendedFunctionInfoEdx: u32 {
+        /// SYSCALL/SYSRET available in 64-bit mode (Bit 11).
+        const CPU_FEATURE_SYSCALL_SYSRET = 1 << 11,
+        /// Execute Disable Bit available (Bit 20).
+        const CPU_FEATURE_EXECUTE_DISABLE = 1 << 20,
+        /// 1-GByte pages are available if 1 (Bit 26).
+        const CPU_FEATURE_1GIB_PAGES = 1 << 26,
+        /// RDTSCP and IA32_TSC_AUX are available if 1 (Bit 27).
+        const CPU_FEATURE_RDTSCP = 1 << 27,
+        /// Intel ® 64 Architecture available if 1 (Bit 29).
+        const CPU_FEATURE_64BIT_MODE = 1 << 29,
+    }
+}
 
 #[cfg(test)]
 #[test]
@@ -3169,29 +3176,29 @@ fn cache_info() {
 #[test]
 fn cache_parameters() {
     let caches: [CacheParameter; 4] = [CacheParameter {
-        eax: 469778721,
-        ebx: 29360191,
-        ecx: 63,
-        edx: 0,
-    },
-    CacheParameter {
-        eax: 469778722,
-        ebx: 29360191,
-        ecx: 63,
-        edx: 0,
-    },
-    CacheParameter {
-        eax: 469778755,
-        ebx: 29360191,
-        ecx: 511,
-        edx: 0,
-    },
-    CacheParameter {
-        eax: 470008163,
-        ebx: 46137407,
-        ecx: 4095,
-        edx: 6,
-    }];
+                                           eax: 469778721,
+                                           ebx: 29360191,
+                                           ecx: 63,
+                                           edx: 0,
+                                       },
+                                       CacheParameter {
+                                           eax: 469778722,
+                                           ebx: 29360191,
+                                           ecx: 63,
+                                           edx: 0,
+                                       },
+                                       CacheParameter {
+                                           eax: 469778755,
+                                           ebx: 29360191,
+                                           ecx: 511,
+                                           edx: 0,
+                                       },
+                                       CacheParameter {
+                                           eax: 470008163,
+                                           ebx: 46137407,
+                                           ecx: 4095,
+                                           edx: 6,
+                                       }];
 
 
     for (idx, cache) in caches.into_iter().enumerate() {
@@ -3441,59 +3448,59 @@ fn extended_functions() {
     let ef = ExtendedFunctionInfo {
         max_eax_value: 8,
         data: [CpuIdResult {
-            eax: 2147483656,
-            ebx: 0,
-            ecx: 0,
-            edx: 0,
-        },
-        CpuIdResult {
-            eax: 0,
-            ebx: 0,
-            ecx: 1,
-            edx: 672139264,
-        },
-        CpuIdResult {
-            eax: 538976288,
-            ebx: 1226842144,
-            ecx: 1818588270,
-            edx: 539578920,
-        },
-        CpuIdResult {
-            eax: 1701998403,
-            ebx: 692933672,
-            ecx: 758475040,
-            edx: 926102323,
-        },
-        CpuIdResult {
-            eax: 1346576469,
-            ebx: 541073493,
-            ecx: 808988209,
-            edx: 8013895,
-        },
-        CpuIdResult {
-            eax: 0,
-            ebx: 0,
-            ecx: 0,
-            edx: 0,
-        },
-        CpuIdResult {
-            eax: 0,
-            ebx: 0,
-            ecx: 16801856,
-            edx: 0,
-        },
-        CpuIdResult {
-            eax: 0,
-            ebx: 0,
-            ecx: 0,
-            edx: 256,
-        },
-        CpuIdResult {
-            eax: 12324,
-            ebx: 0,
-            ecx: 0,
-            edx: 0,
-        }],
+                   eax: 2147483656,
+                   ebx: 0,
+                   ecx: 0,
+                   edx: 0,
+               },
+               CpuIdResult {
+                   eax: 0,
+                   ebx: 0,
+                   ecx: 1,
+                   edx: 672139264,
+               },
+               CpuIdResult {
+                   eax: 538976288,
+                   ebx: 1226842144,
+                   ecx: 1818588270,
+                   edx: 539578920,
+               },
+               CpuIdResult {
+                   eax: 1701998403,
+                   ebx: 692933672,
+                   ecx: 758475040,
+                   edx: 926102323,
+               },
+               CpuIdResult {
+                   eax: 1346576469,
+                   ebx: 541073493,
+                   ecx: 808988209,
+                   edx: 8013895,
+               },
+               CpuIdResult {
+                   eax: 0,
+                   ebx: 0,
+                   ecx: 0,
+                   edx: 0,
+               },
+               CpuIdResult {
+                   eax: 0,
+                   ebx: 0,
+                   ecx: 16801856,
+                   edx: 0,
+               },
+               CpuIdResult {
+                   eax: 0,
+                   ebx: 0,
+                   ecx: 0,
+                   edx: 256,
+               },
+               CpuIdResult {
+                   eax: 12324,
+                   ebx: 0,
+                   ecx: 0,
+                   edx: 0,
+               }],
     };
 
     assert!(ef.processor_brand_string().unwrap() ==


### PR DESCRIPTION
1. good news: solves issue #13 and PR #10 becomes irrelevant, assembly done in rust means that rustc can workout which platform to compile for (I'm thinking about MSVC although i don't have a windows machine to test it)
2. `#![feature(asm)]` is needed, it's a nightly feature but it doesn't do much harm because it's the same assembly that was done in C.
3. forcing the users to pick the nightly channel seems ok because people using this crate will most likely already be using nightly because of the low-level specificity of this crate

ps: github shows a huge hunk of changes in `lib.rs` but most of it is from my text editor redoing the indentation... I can remove it before merging if you like