### PR TITLE
Add an has_rdseed property and deprecate the has_rdseet typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2149,6 +2149,11 @@ impl ExtendedFeatures {
                 CPU_FEATURE_PQE);
 
     check_flag!(doc = "Supports RDSEED.",
+                has_rdseed,
+                ebx,
+                CPU_FEATURE_RDSEED);
+
+    check_flag!(doc = "Supports RDSEED (deprecated alias).",
                 has_rdseet,
                 ebx,
                 CPU_FEATURE_RDSEED);


### PR DESCRIPTION
Closes #20.