### PR TITLE
Migrate to `core::arch` for cpuid on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,5 @@ serde_derive = "1.0"
 serde_json = "1.0"
 
 [build-dependencies]
+rustc_version = "0.2"
 cc = "1"
-
-[features]
-nightly = []
-

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,16 @@
+extern crate rustc_version;
 extern crate cc;
+use rustc_version::{version, version_meta, Channel, Version};
 
-#[cfg(not(feature = "nightly"))]
 fn main() {
-    cc::Build::new().file("src/cpuid.c").compile("libcpuid.a");
-}
+    let nightly = version_meta().unwrap().channel == Channel::Nightly;
+    let newer_than_1_27 = version().unwrap() >= Version::parse("1.27.0").unwrap();
 
-#[cfg(feature = "nightly")]
-fn main() {}
+    let use_arch = nightly || newer_than_1_27;
+
+    if use_arch {
+        println!("cargo:rustc-cfg=feature=\"nightly\"");
+    } else {
+        cc::Build::new().file("src/cpuid.c").compile("libcpuid.a");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate bitflags;
 
-#[cfg(test)]
-#[macro_use]
-extern crate std;
-
 /// Provides `cpuid` on stable by linking against a C implementation.
 #[cfg(not(feature = "nightly"))]
 mod stable_cpuid {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(asm))]
 #![crate_name = "raw_cpuid"]
 #![crate_type = "lib"]
 
@@ -17,22 +16,60 @@ extern crate bitflags;
 #[macro_use]
 extern crate std;
 
+/// Provides `cpuid` on stable by linking against a C implementation.
 #[cfg(not(feature = "nightly"))]
-extern "C" {
-    /// This is a low-level function to query cpuid directly.
-    /// If in doubt use `CpuId` instead.
-    pub fn cpuid(a: *mut u32, b: *mut u32, c: *mut u32, d: *mut u32);
+mod stable_cpuid {
+    use super::CpuIdResult;
+
+    extern "C" {
+        fn cpuid(a: *mut u32, b: *mut u32, c: *mut u32, d: *mut u32);
+    }
+
+    pub fn cpuid_count(mut eax: u32, mut ecx: u32) -> CpuIdResult {
+        let mut ebx = 0u32;
+        let mut edx = 0u32;
+
+        unsafe {
+            cpuid(&mut eax, &mut ebx, &mut ecx, &mut edx);
+        }
+
+        CpuIdResult {
+            eax,
+            ebx,
+            ecx,
+            edx,
+        }
+    }
 }
 
+/// Uses Rust's `cpuid` function from the `arch` module.
 #[cfg(feature = "nightly")]
-/// This is a low-level function to query cpuid directly.
-/// If in doubt use `CpuId` instead.
-pub unsafe fn cpuid(a: &mut u32, b: &mut u32, c: &mut u32, d: &mut u32) {
-    asm!("cpuid"
-      : "+{eax}"(*a), "={ebx}"(*b), "+{ecx}"(*c), "={edx}"(*d)
-      : : : "volatile"
-    );
+mod arch_cpuid {
+    use super::CpuIdResult;
+
+    #[cfg(target_arch = "x86")]
+    use ::core::arch::x86 as arch;
+    #[cfg(target_arch = "x86_64")]
+    use ::core::arch::x86_64 as arch;
+
+    pub fn cpuid_count(a: u32, c: u32) -> CpuIdResult {
+        let result = unsafe {
+            self::arch::__cpuid_count(a, c)
+        };
+
+        CpuIdResult {
+            eax: result.eax,
+            ebx: result.ebx,
+            ecx: result.ecx,
+            edx: result.edx,
+        }
+    }
 }
+
+#[cfg(not(feature = "nightly"))]
+use stable_cpuid as raw_cpuid;
+#[cfg(feature = "nightly")]
+use arch_cpuid as raw_cpuid;
 
 use core::cmp::min;
 use core::fmt;
@@ -46,57 +83,19 @@ mod std {
     pub use core::option;
 }
 
-/// Macro to choose between `cpuid1` and `cpuid2`.
-/// Note: This is a low-level macro to query cpuid directly.
-/// If in doubt use `CpuId` instead.
+/// Macro which queries cpuid directly.
+///
+/// First parameter is cpuid leaf (EAX register value),
+/// second optional parameter is the subleaf (ECX register value).
 #[macro_export]
 macro_rules! cpuid {
     ($eax:expr) => {
-        $crate::cpuid1($eax as u32)
+        $crate::raw_cpuid::cpuid_count($eax as u32, 0)
     };
 
     ($eax:expr, $ecx:expr) => {
-        $crate::cpuid2($eax as u32, $ecx as u32)
+        $crate::raw_cpuid::cpuid_count($eax as u32, $ecx as u32)
     };
-}
-
-/// Execute CPUID instruction with eax and ecx register set.
-/// Note: This is a low-level function to query cpuid directly.
-/// If in doubt use `CpuId` instead.
-pub fn cpuid2(mut eax: u32, mut ecx: u32) -> CpuIdResult {
-    let mut ebx: u32 = 0;
-    let mut edx: u32 = 0;
-
-    unsafe {
-        cpuid(&mut eax, &mut ebx, &mut ecx, &mut edx);
-    }
-
-    CpuIdResult {
-        eax: eax,
-        ebx: ebx,
-        ecx: ecx,
-        edx: edx,
-    }
-}
-
-/// Execute CPUID instruction with eax register set.
-/// Note: This is a low-level function to query cpuid directly.
-/// If in doubt use `CpuId` instead.
-pub fn cpuid1(mut eax: u32) -> CpuIdResult {
-    let mut ebx: u32 = 0;
-    let mut ecx: u32 = 0;
-    let mut edx: u32 = 0;
-
-    unsafe {
-        cpuid(&mut eax, &mut ebx, &mut ecx, &mut edx);
-    }
-
-    CpuIdResult {
-        eax: eax,
-        ebx: ebx,
-        ecx: ecx,
-        edx: edx,
-    }
 }
 
 fn as_bytes(v: &u32) -> &[u8] {


### PR DESCRIPTION
This pull request implements the suggestions in #19. It replaces the ASM-based implementation of `cpuid` on nightly with one which calls the Rust `core::arch::{x86, x86_64}::__cpuid_count` function.

Note that since the standard function only allows us to change EAX and ECX, but not EBX or EDX, I've removed the `cpuid1` / `cpuid2` functions.