### PR TITLE
Detect Intel SHA Extensions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2335,6 +2335,13 @@ impl ExtendedFeatures {
         ebx,
         ExtendedFeaturesEbx::PROCESSOR_TRACE
     );
+
+    check_flag!(
+        doc = "Supports SHA Instructions.",
+        has_sha,
+        ebx,
+        ExtendedFeaturesEbx::SHA
+    );
 }
 
 bitflags! {
@@ -2380,6 +2387,8 @@ bitflags! {
         const CLFLUSHOPT = 1 << 23;
         /// Bit 25: Intel Processor Trace
         const PROCESSOR_TRACE = 1 << 25;
+        /// Bit 29: Intel SHA Extensions
+        const SHA = 1 << 29;
     }
 }
 


### PR DESCRIPTION
Intel ISA reference manual says:

> A processor supports Intel SHA extensions if
> CPUID.(EAX=07H, ECX=0):EBX.SHA [bit 29] = 1. The SHA extensions require only
> XMM state support on operating systems, similar to SSE2 instructions.

See also the Wikipedia summary: https://en.wikipedia.org/wiki/Intel_SHA_extensions