### PR TITLE
Add support for AMD Memory Encryption information

### DIFF
--- a/src/bin/cpuid.rs
+++ b/src/bin/cpuid.rs
@@ -91,4 +91,8 @@ fn main() {
         println!("Extended Function Info");
         println!("{:?}", info);
     });
+    cpuid.get_memory_encryption_info().map(|info| {
+        println!("Memory Encryption Info");
+        println!("{:?}", info);
+    });
 }


### PR DESCRIPTION
This contains the information from leaf 0x8000001F as defined on page
632 of the AMD64 Architecture Programmer’s Manual Volume 3:
General-Purpose and System Instructions.

https://www.amd.com/system/files/TechDocs/24594.pdf