### PR TITLE
Return Option<u64> for get_tsc_frequency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw-cpuid"
-version = "7.0.3"
+version = "8.0.0"
 authors = ["Gerd Zellweger <mail@gerdzellweger.com>"]
 build = "build.rs"
 edition = "2018"

--- a/examples/tsc_frequency.rs
+++ b/examples/tsc_frequency.rs
@@ -31,7 +31,7 @@ fn main() {
 
     let tsc_frequency_hz = cpuid.get_tsc_info().map(|tinfo| {
         if tinfo.nominal_frequency() != 0 {
-            Some(tinfo.tsc_frequency())
+            tinfo.tsc_frequency()
         } else if tinfo.numerator() != 0 && tinfo.denominator() != 0 {
             // Skylake and Kabylake don't report the crystal clock, approximate with base frequency:
             cpuid

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3769,8 +3769,14 @@ impl TscInfo {
     }
 
     /// “TSC frequency” = “core crystal clock frequency” * EBX/EAX.
-    pub fn tsc_frequency(&self) -> u64 {
-        self.nominal_frequency() as u64 * self.numerator() as u64 / self.denominator() as u64
+    pub fn tsc_frequency(&self) -> Option<u64> {
+        // In some case TscInfo is a valid leaf, but the values reported are still 0
+        // we should avoid a division by zero in case denominator ends up being 0.
+        if self.nominal_frequency() == 0 || self.numerator() == 0 || self.denominator() == 0 {
+            return None;
+        }
+
+        Some(self.nominal_frequency() as u64 * self.numerator() as u64 / self.denominator() as u64)
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -84,7 +84,7 @@ fn cache_parameters() {
         },
     ];
 
-    for (idx, cache) in caches.into_iter().enumerate() {
+    for (idx, cache) in caches.iter().enumerate() {
         match idx {
             0 => {
                 assert!(cache.cache_type() == CacheType::Data);


### PR DESCRIPTION
Fixes #31, avoids accidential division by zero for clients.