### PR TITLE
ECX starts from 2 when iterating the SGX sub-leafs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3570,8 +3570,8 @@ impl Iterator for SgxSectionIter {
     type Item = SgxSectionInfo;
 
     fn next(&mut self) -> Option<SgxSectionInfo> {
-        self.current += 1;
         let res = cpuid!(EAX_SGX, self.current);
+        self.current += 1;
         match get_bits(res.eax, 0, 3) {
             0b0001 => Some(SgxSectionInfo::Epc(EpcSection {
                 eax: res.eax,


### PR DESCRIPTION
When iterating the SGX sub-leafs, make sure ECX starts from 2.

https://github.com/gz/rust-cpuid/blob/6554bb914214934b15cccb9d8be4d0f71ac69232/src/lib.rs#L3557-L3567