### PR TITLE
Replace as_bytes with safe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,11 +85,6 @@ macro_rules! cpuid {
     };
 }
 
-fn as_bytes(v: &u32) -> &[u8] {
-    let start = v as *const u32 as *const u8;
-    unsafe { slice::from_raw_parts(start, 4) }
-}
-
 fn get_bits(r: u32, from: u32, to: u32) -> u32 {
     assert!(from <= 31);
     assert!(to <= 31);
@@ -636,7 +631,14 @@ impl Iterator for CacheInfoIter {
             _ => unreachable!(),
         };
 
-        let byte = as_bytes(&reg)[byte_index as usize];
+        let byte = match byte_index {
+            0 => reg,
+            1 => reg >> 8,
+            2 => reg >> 16,
+            3 => reg >> 24,
+            _ => unreachable!(),
+        } as u8;
+
         if byte == 0 {
             self.current += 1;
             return self.next();


### PR DESCRIPTION
~Is it intentional that the conversion in `as_bytes()` depends on the endianness?~

~If yes, there should maybe be a comment mentioning it.~

~I *think* it is not, so it may be best to replace it with a (not much longer) version without unsafe.~

Nevermind the endianness question. I guess x86 is just always little endian. I believe it's still best to avoid unsafe code, when the safe version is not significantly longer or slower.