### PR TITLE
Break compilation on SGX and 32-bit x86 without SSE (fixes #41)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,14 @@ extern crate bitflags;
 pub mod native_cpuid {
     use super::CpuIdResult;
 
-    #[cfg(target_arch = "x86")]
+    #[cfg(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"))]
     use core::arch::x86 as arch;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", not(target_env = "sgx")))]
     use core::arch::x86_64 as arch;
 
     pub fn cpuid_count(a: u32, c: u32) -> CpuIdResult {
+        // Safety: CPUID is supported on all x86_64 CPUs and all x86 CPUs with
+        // SSE, but not by SGX.
         let result = unsafe { self::arch::__cpuid_count(a, c) };
 
         CpuIdResult {


### PR DESCRIPTION
A possible fix for #41.

Unfortunately this would break compilation for 32-bit targets without SSE, a few of which would support CPUID. Proper runtime detection would look like https://doc.rust-lang.org/stable/src/core/up/up/stdarch/crates/core_arch/src/x86/cpuid.rs.html#110-156, but needs C again, to accomplish it on stable Rust.