### PR TITLE
Comprehensive Debug-impls for all structs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2067,7 +2067,10 @@ impl Debug for FeatureInfo {
             .field("brand_index", &self.brand_index())
             .field("cflush_cache_line_size", &self.cflush_cache_line_size())
             .field("initial_local_apic_id", &self.initial_local_apic_id())
-            .field("max_logical_processor_ids", &self.max_logical_processor_ids())
+            .field(
+                "max_logical_processor_ids",
+                &self.max_logical_processor_ids(),
+            )
             .field("edx_ecx", &self.edx_ecx)
             .finish()
     }
@@ -2241,7 +2244,7 @@ impl Debug for CacheParametersIter {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let mut debug = f.debug_list();
         self.clone().for_each(|ref item| {
-           debug.entry(item);
+            debug.entry(item);
         });
         debug.finish()
     }
@@ -2648,15 +2651,24 @@ impl Debug for ThermalPowerInfo {
             .field("has_hwp", &self.has_hwp())
             .field("has_hwp_notification", &self.has_hwp_notification())
             .field("has_hwp_activity_window", &self.has_hwp_activity_window())
-            .field("has_hwp_energy_performance_preference", &self.has_hwp_energy_performance_preference())
-            .field("has_hwp_package_level_request", &self.has_hwp_package_level_request())
+            .field(
+                "has_hwp_energy_performance_preference",
+                &self.has_hwp_energy_performance_preference(),
+            )
+            .field(
+                "has_hwp_package_level_request",
+                &self.has_hwp_package_level_request(),
+            )
             .field("has_hdc", &self.has_hdc())
             .field("has_turbo_boost3", &self.has_turbo_boost3())
             .field("has_hwp_capabilities", &self.has_hwp_capabilities())
             .field("has_hwp_peci_override", &self.has_hwp_peci_override())
             .field("has_flexible_hwp", &self.has_flexible_hwp())
             .field("has_hwp_fast_access_mode", &self.has_hwp_fast_access_mode())
-            .field("has_ignore_idle_processor_hwp_request", &self.has_ignore_idle_processor_hwp_request())
+            .field(
+                "has_ignore_idle_processor_hwp_request",
+                &self.has_ignore_idle_processor_hwp_request(),
+            )
             .field("has_hw_coord_feedback", &self.has_hw_coord_feedback())
             .field("has_energy_bias_pref", &self.has_energy_bias_pref())
             .finish()
@@ -3557,8 +3569,14 @@ impl Debug for ExtendedStateInfo {
         f.debug_struct("ExtendedStateInfo")
             .field("eax", &self.eax)
             .field("ecx1", &self.ecx1)
-            .field("xsave_area_size_enabled_features", &self.xsave_area_size_enabled_features())
-            .field("xsave_area_size_supported_features", &self.xsave_area_size_supported_features())
+            .field(
+                "xsave_area_size_enabled_features",
+                &self.xsave_area_size_enabled_features(),
+            )
+            .field(
+                "xsave_area_size_supported_features",
+                &self.xsave_area_size_supported_features(),
+            )
             .field("has_xsaveopt", &self.has_xsaveopt())
             .field("has_xsavec", &self.has_xsavec())
             .field("has_xgetbv", &self.has_xgetbv())
@@ -3618,7 +3636,7 @@ impl Debug for ExtendedStateIter {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut debug = f.debug_list();
         self.clone().for_each(|ref item| {
-           debug.entry(item);
+            debug.entry(item);
         });
         debug.finish()
     }
@@ -3966,7 +3984,10 @@ impl Debug for MemBwAllocationInfo {
         f.debug_struct("MemBwAllocationInfo")
             .field("max_hba_throttling", &self.max_hba_throttling())
             .field("highest_cos", &self.highest_cos())
-            .field("has_linear_response_delay", &self.has_linear_response_delay())
+            .field(
+                "has_linear_response_delay",
+                &self.has_linear_response_delay(),
+            )
             .finish()
     }
 }
@@ -4046,8 +4067,14 @@ impl Debug for SgxInfo {
                 &self.max_enclave_size_non_64bit(),
             )
             .field("max_enclave_size_64bit", &self.max_enclave_size_64bit())
-            .field("has_encls_leaves_etrackc_erdinfo_eldbc_elduc", &self.has_encls_leaves_etrackc_erdinfo_eldbc_elduc())
-            .field("has_enclv_leaves_einvirtchild_edecvirtchild_esetcontext", &self.has_enclv_leaves_einvirtchild_edecvirtchild_esetcontext())
+            .field(
+                "has_encls_leaves_etrackc_erdinfo_eldbc_elduc",
+                &self.has_encls_leaves_etrackc_erdinfo_eldbc_elduc(),
+            )
+            .field(
+                "has_enclv_leaves_einvirtchild_edecvirtchild_esetcontext",
+                &self.has_enclv_leaves_einvirtchild_edecvirtchild_esetcontext(),
+            )
             .field("sgx_section_iter", &self.iter())
             .finish()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,7 +388,7 @@ impl CpuId {
                 eax: ThermalPowerFeaturesEax { bits: res.eax },
                 ebx: res.ebx,
                 ecx: ThermalPowerFeaturesEcx { bits: res.ecx },
-                edx: res.edx,
+                _edx: res.edx,
             })
         } else {
             None
@@ -400,10 +400,10 @@ impl CpuId {
         if self.leaf_is_supported(EAX_STRUCTURED_EXTENDED_FEATURE_INFO) {
             let res = self.read.cpuid1(EAX_STRUCTURED_EXTENDED_FEATURE_INFO);
             Some(ExtendedFeatures {
-                eax: res.eax,
+                _eax: res.eax,
                 ebx: ExtendedFeaturesEbx { bits: res.ebx },
                 ecx: ExtendedFeaturesEcx { bits: res.ecx },
-                edx: res.edx,
+                _edx: res.edx,
             })
         } else {
             None
@@ -427,7 +427,7 @@ impl CpuId {
             Some(PerformanceMonitoringInfo {
                 eax: res.eax,
                 ebx: PerformanceMonitoringFeaturesEbx { bits: res.ebx },
-                ecx: res.ecx,
+                _ecx: res.ecx,
                 edx: res.edx,
             })
         } else {
@@ -457,11 +457,11 @@ impl CpuId {
                 eax: ExtendedStateInfoXCR0Flags { bits: res.eax },
                 ebx: res.ebx,
                 ecx: res.ecx,
-                edx: res.edx,
+                _edx: res.edx,
                 eax1: res1.eax,
                 ebx1: res1.ebx,
                 ecx1: ExtendedStateInfoXSSFlags { bits: res1.ecx },
-                edx1: res1.edx,
+                _edx1: res1.edx,
             })
         } else {
             None
@@ -507,7 +507,7 @@ impl CpuId {
                     read: self.read,
                     eax: res.eax,
                     ebx: res.ebx,
-                    ecx: res.ecx,
+                    _ecx: res.ecx,
                     edx: res.edx,
                     eax1: res1.eax,
                     ebx1: res1.ebx,
@@ -531,10 +531,10 @@ impl CpuId {
             };
 
             Some(ProcessorTraceInfo {
-                eax: res.eax,
+                _eax: res.eax,
                 ebx: res.ebx,
                 ecx: res.ecx,
-                edx: res.edx,
+                _edx: res.edx,
                 leaf1: res1,
             })
         } else {
@@ -2476,7 +2476,7 @@ pub struct ThermalPowerInfo {
     eax: ThermalPowerFeaturesEax,
     ebx: u32,
     ecx: ThermalPowerFeaturesEcx,
-    edx: u32,
+    _edx: u32,
 }
 
 impl ThermalPowerInfo {
@@ -2728,10 +2728,10 @@ bitflags! {
 #[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ExtendedFeatures {
-    eax: u32,
+    _eax: u32,
     ebx: ExtendedFeaturesEbx,
     ecx: ExtendedFeaturesEcx,
-    edx: u32,
+    _edx: u32,
 }
 
 impl ExtendedFeatures {
@@ -3118,7 +3118,7 @@ impl Debug for DirectCacheAccessInfo {
 pub struct PerformanceMonitoringInfo {
     eax: u32,
     ebx: PerformanceMonitoringFeaturesEbx,
-    ecx: u32,
+    _ecx: u32,
     edx: u32,
 }
 
@@ -3417,11 +3417,11 @@ pub struct ExtendedStateInfo {
     eax: ExtendedStateInfoXCR0Flags,
     ebx: u32,
     ecx: u32,
-    edx: u32,
+    _edx: u32,
     eax1: u32,
     ebx1: u32,
     ecx1: ExtendedStateInfoXSSFlags,
-    edx1: u32,
+    _edx1: u32,
 }
 
 impl ExtendedStateInfo {
@@ -3979,7 +3979,7 @@ pub struct SgxInfo {
     read: CpuIdReader,
     eax: u32,
     ebx: u32,
-    ecx: u32,
+    _ecx: u32,
     edx: u32,
     eax1: u32,
     ebx1: u32,
@@ -4131,10 +4131,10 @@ impl EpcSection {
 #[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ProcessorTraceInfo {
-    eax: u32,
+    _eax: u32,
     ebx: u32,
     ecx: u32,
-    edx: u32,
+    _edx: u32,
     leaf1: Option<CpuIdResult>,
 }
 
@@ -4388,7 +4388,7 @@ impl Iterator for DatIter {
             }
 
             return Some(DatInfo {
-                eax: res.eax,
+                _eax: res.eax,
                 ebx: res.ebx,
                 ecx: res.ecx,
                 edx: res.edx,
@@ -4411,7 +4411,7 @@ impl Debug for DatIter {
 #[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct DatInfo {
-    eax: u32,
+    _eax: u32,
     ebx: u32,
     ecx: u32,
     edx: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,10 +74,10 @@ pub mod native_cpuid {
 
 use core::cmp::min;
 use core::fmt;
+use core::fmt::{Debug, Formatter};
 use core::mem::size_of;
 use core::slice;
 use core::str;
-use core::fmt::{Formatter, Debug};
 
 #[cfg(not(test))]
 mod std {
@@ -723,8 +723,14 @@ impl Debug for CpuId {
             .field("monitor_mwait_info", &self.get_monitor_mwait_info())
             .field("thermal_power_info", &self.get_thermal_power_info())
             .field("extended_feature_info", &self.get_extended_feature_info())
-            .field("direct_cache_access_info", &self.get_direct_cache_access_info())
-            .field("performance_monitoring_info", &self.get_performance_monitoring_info())
+            .field(
+                "direct_cache_access_info",
+                &self.get_direct_cache_access_info(),
+            )
+            .field(
+                "performance_monitoring_info",
+                &self.get_performance_monitoring_info(),
+            )
             .field("extended_topology_info", &self.get_extended_topology_info())
             .field("extended_state_info", &self.get_extended_state_info())
             .field("rdt_monitoring_info", &self.get_rdt_monitoring_info())
@@ -732,8 +738,14 @@ impl Debug for CpuId {
             .field("sgx_info", &self.get_sgx_info())
             .field("processor_trace_info", &self.get_processor_trace_info())
             .field("tsc_info", &self.get_tsc_info())
-            .field("processor_frequency_info", &self.get_processor_frequency_info())
-            .field("deterministic_address_translation_info", &self.deterministic_address_translation_info())
+            .field(
+                "processor_frequency_info",
+                &self.get_processor_frequency_info(),
+            )
+            .field(
+                "deterministic_address_translation_info",
+                &self.deterministic_address_translation_info(),
+            )
             .field("soc_vendor_info", &self.get_soc_vendor_info())
             .field("hypervisor_info", &self.get_hypervisor_info())
             .field("extended_function_info", &self.get_extended_function_info())
@@ -2443,7 +2455,10 @@ impl Debug for MonitorMwaitInfo {
             .field("smallest_monitor_line", &self.smallest_monitor_line())
             .field("largest_monitor_line", &self.largest_monitor_line())
             .field("extensions_supported", &self.extensions_supported())
-            .field("interrupts_as_break_event", &self.interrupts_as_break_event())
+            .field(
+                "interrupts_as_break_event",
+                &self.interrupts_as_break_event(),
+            )
             .field("supported_c0_states", &self.supported_c0_states())
             .field("supported_c1_states", &self.supported_c1_states())
             .field("supported_c2_states", &self.supported_c2_states())
@@ -3196,7 +3211,10 @@ impl Debug for PerformanceMonitoringInfo {
             .field("counter_bit_width", &self.counter_bit_width())
             .field("ebx_length", &self.ebx_length())
             .field("fixed_function_counters", &self.fixed_function_counters())
-            .field("fixed_function_counters_bit_width", &self.fixed_function_counters_bit_width())
+            .field(
+                "fixed_function_counters_bit_width",
+                &self.fixed_function_counters_bit_width(),
+            )
             .finish()
     }
 }
@@ -3800,7 +3818,10 @@ impl Debug for RdtAllocationInfo {
             .field("ebx", &(self.ebx as *const u32))
             .field("l3_cat", &self.l3_cat())
             .field("l2_cat", &self.l2_cat())
-            .field("memory_bandwidth_allocation", &self.memory_bandwidth_allocation())
+            .field(
+                "memory_bandwidth_allocation",
+                &self.memory_bandwidth_allocation(),
+            )
             .finish()
     }
 }
@@ -4008,7 +4029,10 @@ impl Debug for SgxInfo {
             .field("ecx1", &(self.ecx1 as *const u32))
             .field("edx1", &(self.edx1 as *const u32))
             .field("miscselect", &self.miscselect())
-            .field("max_enclave_size_non_64bit", &self.max_enclave_size_non_64bit())
+            .field(
+                "max_enclave_size_non_64bit",
+                &self.max_enclave_size_non_64bit(),
+            )
             .field("max_enclave_size_64bit", &self.max_enclave_size_64bit())
             .field("iter", &self.iter())
             .finish()
@@ -4212,10 +4236,22 @@ impl Debug for ProcessorTraceInfo {
             .field("ecx", &(self.ecx as *const u32))
             .field("edx", &(self.edx as *const u32))
             .field("leaf1", &self.leaf1)
-            .field("configurable_address_ranges", &(self.configurable_address_ranges() as *const u32))
-            .field("supported_mtc_period_encodings", &(self.supported_mtc_period_encodings() as *const u32))
-            .field("supported_cycle_threshold_value_encodings", &(self.supported_cycle_threshold_value_encodings() as *const u32))
-            .field("supported_psb_frequency_encodings", &(self.supported_psb_frequency_encodings() as *const u32))
+            .field(
+                "configurable_address_ranges",
+                &(self.configurable_address_ranges() as *const u32),
+            )
+            .field(
+                "supported_mtc_period_encodings",
+                &(self.supported_mtc_period_encodings() as *const u32),
+            )
+            .field(
+                "supported_cycle_threshold_value_encodings",
+                &(self.supported_cycle_threshold_value_encodings() as *const u32),
+            )
+            .field(
+                "supported_psb_frequency_encodings",
+                &(self.supported_psb_frequency_encodings() as *const u32),
+            )
             .finish()
     }
 }
@@ -4496,9 +4532,7 @@ impl SoCVendorInfo {
             let r1 = cpuid!(EAX_SOC_VENDOR_INFO, 1);
             let r2 = cpuid!(EAX_SOC_VENDOR_INFO, 2);
             let r3 = cpuid!(EAX_SOC_VENDOR_INFO, 3);
-            Some(
-                SoCVendorBrand { data: [r1, r2, r3] }
-            )
+            Some(SoCVendorBrand { data: [r1, r2, r3] })
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ use core::fmt;
 use core::mem::size_of;
 use core::slice;
 use core::str;
+use core::fmt::{Formatter, Debug};
 
 #[cfg(not(test))]
 mod std {
@@ -191,7 +192,6 @@ impl Vendor {
 }
 
 /// Main type used to query for information about the CPU we're running on.
-#[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct CpuId {
     #[cfg_attr(feature = "serialize", serde(skip))]
@@ -207,7 +207,7 @@ impl Default for CpuId {
 }
 
 /// Low-level data-structure to store result of cpuid instruction.
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct CpuIdResult {
@@ -224,6 +224,17 @@ pub struct CpuIdResult {
 impl CpuIdResult {
     pub fn all_zero(&self) -> bool {
         self.eax == 0 && self.ebx == 0 && self.ecx == 0 && self.edx == 0
+    }
+}
+
+impl Debug for CpuIdResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CpuIdResult")
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &(self.ebx as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .finish()
     }
 }
 
@@ -699,7 +710,39 @@ impl CpuId {
 /// ## Technical Background
 /// The vendor info is a 12-byte (96 bit) long string stored in `ebx`, `edx` and `ecx` by
 /// the corresponding `cpuid` instruction.
-#[derive(Debug, Default)]
+impl Debug for CpuId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CpuId")
+            .field("vendor", &self.vendor)
+            .field("supported_leafs", &(self.supported_leafs as *const u32))
+            .field("vendor_info", &self.get_vendor_info())
+            .field("feature_info", &self.get_feature_info())
+            .field("cache_info", &self.get_cache_info())
+            .field("processor_serial", &self.get_processor_serial())
+            .field("cache_parameters", &self.get_cache_parameters())
+            .field("monitor_mwait_info", &self.get_monitor_mwait_info())
+            .field("thermal_power_info", &self.get_thermal_power_info())
+            .field("extended_feature_info", &self.get_extended_feature_info())
+            .field("direct_cache_access_info", &self.get_direct_cache_access_info())
+            .field("performance_monitoring_info", &self.get_performance_monitoring_info())
+            .field("extended_topology_info", &self.get_extended_topology_info())
+            .field("extended_state_info", &self.get_extended_state_info())
+            .field("rdt_monitoring_info", &self.get_rdt_monitoring_info())
+            .field("rdt_allocation_info", &self.get_rdt_allocation_info())
+            .field("sgx_info", &self.get_sgx_info())
+            .field("processor_trace_info", &self.get_processor_trace_info())
+            .field("tsc_info", &self.get_tsc_info())
+            .field("processor_frequency_info", &self.get_processor_frequency_info())
+            .field("deterministic_address_translation_info", &self.deterministic_address_translation_info())
+            .field("soc_vendor_info", &self.get_soc_vendor_info())
+            .field("hypervisor_info", &self.get_hypervisor_info())
+            .field("extended_function_info", &self.get_extended_function_info())
+            .field("memory_encryption_info", &self.get_memory_encryption_info())
+            .finish()
+    }
+}
+
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct VendorInfo {
@@ -722,8 +765,20 @@ impl VendorInfo {
     }
 }
 
+impl Debug for VendorInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VendorInfo")
+            // the pointer cast trick will print the value as hex with leading "0x"
+            .field("ebx", &(self.ebx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("brand_string", &self.as_string())
+            .finish()
+    }
+}
+
 /// Used to iterate over cache information contained in cpuid instruction.
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct CacheInfoIter {
     current: u32,
@@ -776,6 +831,18 @@ impl Iterator for CacheInfoIter {
         }
 
         None
+    }
+}
+
+impl Debug for CacheInfoIter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CacheInfoIter")
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &(self.ebx as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            // TODO include elements in debug output
+            .finish()
     }
 }
 
@@ -1386,7 +1453,7 @@ impl fmt::Display for VendorInfo {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ProcessorSerial {
     ecx: u32,
@@ -1411,7 +1478,20 @@ impl ProcessorSerial {
     }
 }
 
-#[derive(Debug, Default)]
+impl Debug for ProcessorSerial {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ProcessorSerial")
+            // the pointer cast trick will print the value as hex with leading "0x"
+            .field("ecx", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("serial_lower", &self.serial_lower())
+            .field("serial_middle", &self.serial_middle())
+            .field("serial_middle", &self.serial_middle())
+            .finish()
+    }
+}
+
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct FeatureInfo {
     eax: u32,
@@ -1964,6 +2044,16 @@ impl FeatureInfo {
     );
 }
 
+impl Debug for FeatureInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeatureInfo")
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &(self.ebx as *const u32))
+            .field("edx_ecx", &self.edx_ecx)
+            .finish()
+    }
+}
+
 bitflags! {
     #[derive(Default)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
@@ -2094,7 +2184,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct CacheParametersIter {
     #[cfg_attr(feature = "serialize", serde(skip))]
@@ -2128,7 +2218,15 @@ impl Iterator for CacheParametersIter {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default)]
+impl Debug for CacheParametersIter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CacheParametersIter")
+            // TODO find nice way to output all elements of the iterator here!
+            .finish()
+    }
+}
+
+#[derive(Copy, Clone, Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct CacheParameter {
     eax: u32,
@@ -2238,7 +2336,32 @@ impl CacheParameter {
     }
 }
 
-#[derive(Debug, Default)]
+impl Debug for CacheParameter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CacheParameter")
+            // the pointer cast trick will print the value as hex with leading "0x"
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &(self.ebx as *const u32))
+            .field("eax", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("cache_type", &self.cache_type())
+            .field("level", &self.level())
+            .field("is_self_initializing", &self.is_self_initializing())
+            .field("is_fully_associative", &self.is_fully_associative())
+            .field("max_cores_for_cache", &self.max_cores_for_cache())
+            .field("max_cores_for_package", &self.max_cores_for_package())
+            .field("coherency_line_size", &self.coherency_line_size())
+            .field("physical_line_partitions", &self.physical_line_partitions())
+            .field("associativity", &self.associativity())
+            .field("sets", &self.sets())
+            .field("is_write_back_invalidate", &self.is_write_back_invalidate())
+            .field("is_inclusive", &self.is_inclusive())
+            .field("has_complex_indexing", &self.has_complex_indexing())
+            .finish()
+    }
+}
+
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct MonitorMwaitInfo {
     eax: u32,
@@ -2309,7 +2432,31 @@ impl MonitorMwaitInfo {
     }
 }
 
-#[derive(Debug, Default)]
+impl Debug for MonitorMwaitInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MonitorMwaitInfo")
+            // the pointer cast trick will print the value as hex with leading "0x"
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &(self.ebx as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("smallest_monitor_line", &self.smallest_monitor_line())
+            .field("largest_monitor_line", &self.largest_monitor_line())
+            .field("extensions_supported", &self.extensions_supported())
+            .field("interrupts_as_break_event", &self.interrupts_as_break_event())
+            .field("supported_c0_states", &self.supported_c0_states())
+            .field("supported_c1_states", &self.supported_c1_states())
+            .field("supported_c2_states", &self.supported_c2_states())
+            .field("supported_c3_states", &self.supported_c3_states())
+            .field("supported_c4_states", &self.supported_c4_states())
+            .field("supported_c5_states", &self.supported_c5_states())
+            .field("supported_c6_states", &self.supported_c6_states())
+            .field("supported_c7_states", &self.supported_c7_states())
+            .finish()
+    }
+}
+
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ThermalPowerInfo {
     eax: ThermalPowerFeaturesEax,
@@ -2475,6 +2622,18 @@ impl ThermalPowerInfo {
     );
 }
 
+impl Debug for ThermalPowerInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ThermalPowerInfo")
+            .field("eax", &self.eax)
+            // the pointer cast trick will print the value as hex with leading "0x"
+            .field("ebx", &(self.ebx as *const u32))
+            .field("ecx", &self.ecx)
+            .field("edx", &(self.edx as *const u32))
+            .finish()
+    }
+}
+
 bitflags! {
     #[derive(Default)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
@@ -2537,7 +2696,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ExtendedFeatures {
     eax: u32,
@@ -2791,6 +2950,18 @@ impl ExtendedFeatures {
     }
 }
 
+impl Debug for ExtendedFeatures {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ExtendedFeatures")
+            // the pointer cast trick will print the value as hex with leading "0x"
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &self.ebx)
+            .field("ecx", &self.ecx)
+            .field("edx", &(self.edx as *const u32))
+            .finish()
+    }
+}
+
 bitflags! {
     #[derive(Default)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
@@ -2894,7 +3065,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct DirectCacheAccessInfo {
     eax: u32,
@@ -2907,7 +3078,16 @@ impl DirectCacheAccessInfo {
     }
 }
 
-#[derive(Debug, Default)]
+impl Debug for DirectCacheAccessInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DirectCacheAccessInfo")
+            .field("eax", &(self.eax as *const u32))
+            .field("dca_cap_value", &self.get_dca_cap_value())
+            .finish()
+    }
+}
+
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct PerformanceMonitoringInfo {
     eax: u32,
@@ -3004,6 +3184,23 @@ impl PerformanceMonitoringInfo {
     );
 }
 
+impl Debug for PerformanceMonitoringInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PerformanceMonitoringInfo")
+            .field("eax", &(self.eax as *const u32))
+            .field("eax", &self.ebx)
+            .field("ecx", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("version_id", &self.version_id())
+            .field("number_of_counters", &self.number_of_counters())
+            .field("counter_bit_width", &self.counter_bit_width())
+            .field("ebx_length", &self.ebx_length())
+            .field("fixed_function_counters", &self.fixed_function_counters())
+            .field("fixed_function_counters_bit_width", &self.fixed_function_counters_bit_width())
+            .finish()
+    }
+}
+
 bitflags! {
     #[derive(Default)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
@@ -3027,7 +3224,7 @@ bitflags! {
 
 /// Iterates over the system topology in order to retrieve more
 /// system information at each level of the topology.
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ExtendedTopologyIter {
     #[cfg_attr(feature = "serialize", serde(skip))]
@@ -3129,6 +3326,14 @@ impl Iterator for ExtendedTopologyIter {
     }
 }
 
+impl Debug for ExtendedTopologyIter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ExtendedTopologyIter")
+            // TODO find nice way to display all items behind the iterator
+            .finish()
+    }
+}
+
 bitflags! {
     #[derive(Default)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
@@ -3177,7 +3382,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ExtendedStateInfo {
     #[cfg_attr(feature = "serialize", serde(skip))]
@@ -3320,6 +3525,21 @@ impl ExtendedStateInfo {
     }
 }
 
+impl Debug for ExtendedStateInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ExtendedStateInfo")
+            .field("eax", &self.eax)
+            .field("ebx", &(self.ebx as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("eax1", &(self.eax1 as *const u32))
+            .field("ebx1", &(self.ebx1 as *const u32))
+            .field("ecx1", &self.ecx1)
+            .field("edx1", &(self.edx1 as *const u32))
+            .finish()
+    }
+}
+
 #[derive(Debug, Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ExtendedStateIter {
@@ -3408,7 +3628,7 @@ impl ExtendedState {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct RdtMonitoringInfo {
     #[cfg_attr(feature = "serialize", serde(skip))]
@@ -3446,7 +3666,18 @@ impl RdtMonitoringInfo {
     }
 }
 
-#[derive(Debug, Default)]
+impl Debug for RdtMonitoringInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RdtMonitoringInfo")
+            .field("ebx", &(self.ebx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("rmid_range", &self.rmid_range())
+            .field("l3_monitoring", &self.l3_monitoring())
+            .finish()
+    }
+}
+
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct L3MonitoringInfo {
     ebx: u32,
@@ -3487,7 +3718,19 @@ impl L3MonitoringInfo {
     );
 }
 
-#[derive(Debug, Default)]
+impl Debug for L3MonitoringInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("L3MonitoringInfo")
+            .field("ebx", &(self.ebx as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("conversion_factor", &self.conversion_factor())
+            .field("maximum_rmid_range", &self.maximum_rmid_range())
+            .finish()
+    }
+}
+
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct RdtAllocationInfo {
     #[cfg_attr(feature = "serialize", serde(skip))]
@@ -3551,8 +3794,19 @@ impl RdtAllocationInfo {
     }
 }
 
+impl Debug for RdtAllocationInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RdtAllocationInfo")
+            .field("ebx", &(self.ebx as *const u32))
+            .field("l3_cat", &self.l3_cat())
+            .field("l2_cat", &self.l2_cat())
+            .field("memory_bandwidth_allocation", &self.memory_bandwidth_allocation())
+            .finish()
+    }
+}
+
 /// L3 Cache Allocation Technology Enumeration Sub-leaf (EAX = 10H, ECX = ResID = 1).
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct L3CatInfo {
     eax: u32,
@@ -3585,8 +3839,22 @@ impl L3CatInfo {
     );
 }
 
+impl Debug for L3CatInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("L3CatInfo")
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &(self.ebx as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("capacity_mask_length", &self.capacity_mask_length())
+            .field("isolation_bitmap", &self.isolation_bitmap())
+            .field("highest_cos", &self.highest_cos())
+            .finish()
+    }
+}
+
 /// L2 Cache Allocation Technology Enumeration Sub-leaf (EAX = 10H, ECX = ResID = 2).
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct L2CatInfo {
     eax: u32,
@@ -3611,8 +3879,21 @@ impl L2CatInfo {
     }
 }
 
+impl Debug for L2CatInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("L2CatInfo")
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &(self.ebx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("capacity_mask_length", &self.capacity_mask_length())
+            .field("isolation_bitmap", &self.isolation_bitmap())
+            .field("highest_cos", &self.highest_cos())
+            .finish()
+    }
+}
+
 /// Memory Bandwidth Allocation Enumeration Sub-leaf (EAX = 10H, ECX = ResID = 3).
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct MemBwAllocationInfo {
     eax: u32,
@@ -3639,8 +3920,20 @@ impl MemBwAllocationInfo {
     );
 }
 
+impl Debug for MemBwAllocationInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MemBwAllocationInfo")
+            .field("eax", &(self.eax as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("max_hba_throttling", &self.max_hba_throttling())
+            .field("highest_cos", &self.highest_cos())
+            .finish()
+    }
+}
+
 /// Intel SGX Capability Enumeration Leaf, sub-leaf 0 (EAX = 12H, ECX = 0 and ECX = 1)
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct SgxInfo {
     #[cfg_attr(feature = "serialize", serde(skip))]
@@ -3703,8 +3996,27 @@ impl SgxInfo {
     }
 }
 
+impl Debug for SgxInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SgxInfo")
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &(self.ebx as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("eax1", &(self.eax1 as *const u32))
+            .field("ebx1", &(self.ebx1 as *const u32))
+            .field("ecx1", &(self.ecx1 as *const u32))
+            .field("edx1", &(self.edx1 as *const u32))
+            .field("miscselect", &self.miscselect())
+            .field("max_enclave_size_non_64bit", &self.max_enclave_size_non_64bit())
+            .field("max_enclave_size_64bit", &self.max_enclave_size_64bit())
+            .field("iter", &self.iter())
+            .finish()
+    }
+}
+
 /// Iterator over the SGX sub-leafs (ECX >= 2).
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct SgxSectionIter {
     #[cfg_attr(feature = "serialize", serde(skip))]
@@ -3727,6 +4039,14 @@ impl Iterator for SgxSectionIter {
             })),
             _ => None,
         }
+    }
+}
+
+impl Debug for SgxSectionIter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SgxSectionIter")
+            // TODO find way to include all elements here nicely
+            .finish()
     }
 }
 
@@ -3770,7 +4090,7 @@ impl EpcSection {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ProcessorTraceInfo {
     eax: u32,
@@ -3884,6 +4204,22 @@ impl ProcessorTraceInfo {
     }
 }
 
+impl Debug for ProcessorTraceInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ProcessorTraceInfo")
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &(self.ebx as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("leaf1", &self.leaf1)
+            .field("configurable_address_ranges", &(self.configurable_address_ranges() as *const u32))
+            .field("supported_mtc_period_encodings", &(self.supported_mtc_period_encodings() as *const u32))
+            .field("supported_cycle_threshold_value_encodings", &(self.supported_cycle_threshold_value_encodings() as *const u32))
+            .field("supported_psb_frequency_encodings", &(self.supported_psb_frequency_encodings() as *const u32))
+            .finish()
+    }
+}
+
 /// Time Stamp Counter and Nominal Core Crystal Clock Information Leaf.
 #[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
@@ -3896,9 +4232,13 @@ pub struct TscInfo {
 impl fmt::Debug for TscInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("TscInfo")
-            .field("denominator/eax", &self.denominator())
-            .field("numerator/ebx", &self.numerator())
-            .field("nominal_frequency/ecx", &self.nominal_frequency())
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &(self.ebx as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("denominator", &self.denominator())
+            .field("numerator", &self.numerator())
+            .field("nominal_frequency", &self.nominal_frequency())
+            .field("tsc_frequency", &self.tsc_frequency())
             .finish()
     }
 }
@@ -3936,7 +4276,7 @@ impl TscInfo {
 }
 
 /// Processor Frequency Information
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ProcessorFrequencyInfo {
     eax: u32,
@@ -3958,6 +4298,19 @@ impl ProcessorFrequencyInfo {
     /// Bus (Reference) Frequency (in MHz).
     pub fn bus_frequency(&self) -> u16 {
         get_bits(self.ecx, 0, 15) as u16
+    }
+}
+
+impl fmt::Debug for ProcessorFrequencyInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ProcessorFrequencyInfo")
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &(self.ebx as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("processor_base_frequency", &self.processor_base_frequency())
+            .field("processor_max_frequency", &self.processor_max_frequency())
+            .field("bus_frequency", &self.bus_frequency())
+            .finish()
     }
 }
 
@@ -4112,7 +4465,7 @@ impl Default for DatType {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct SoCVendorInfo {
     #[cfg_attr(feature = "serialize", serde(skip))]
@@ -4137,12 +4490,18 @@ impl SoCVendorInfo {
         self.edx
     }
 
-    pub fn get_vendor_brand(&self) -> SoCVendorBrand {
-        assert!(self.eax >= 3); // Leaf 17H is valid if MaxSOCID_Index >= 3.
-        let r1 = self.read.cpuid2(EAX_SOC_VENDOR_INFO, 1);
-        let r2 = self.read.cpuid2(EAX_SOC_VENDOR_INFO, 2);
-        let r3 = self.read.cpuid2(EAX_SOC_VENDOR_INFO, 3);
-        SoCVendorBrand { data: [r1, r2, r3] }
+    pub fn get_vendor_brand(&self) -> Option<SoCVendorBrand> {
+        // Leaf 17H is valid if MaxSOCID_Index >= 3.
+        if self.eax >= 3 {
+            let r1 = cpuid!(EAX_SOC_VENDOR_INFO, 1);
+            let r2 = cpuid!(EAX_SOC_VENDOR_INFO, 2);
+            let r3 = cpuid!(EAX_SOC_VENDOR_INFO, 3);
+            Some(
+                SoCVendorBrand { data: [r1, r2, r3] }
+            )
+        } else {
+            None
+        }
     }
 
     pub fn get_vendor_attributes(&self) -> Option<SoCVendorAttributesIter> {
@@ -4155,6 +4514,22 @@ impl SoCVendorInfo {
         } else {
             None
         }
+    }
+}
+
+impl fmt::Debug for SoCVendorInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SoCVendorInfo")
+            .field("eax", &(self.eax as *const u32))
+            .field("ebx", &(self.ebx as *const u32))
+            .field("ecx", &(self.ecx as *const u32))
+            .field("edx", &(self.edx as *const u32))
+            .field("soc_vendor_id", &self.get_soc_vendor_id())
+            .field("project_id", &self.get_project_id())
+            .field("stepping_id", &self.get_stepping_id())
+            .field("vendor_brand", &self.get_vendor_brand())
+            .field("vendor_attributes", &self.get_vendor_attributes())
+            .finish()
     }
 }
 
@@ -4219,7 +4594,8 @@ pub struct HypervisorInfo {
 impl fmt::Debug for HypervisorInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("HypervisorInfo")
-            .field("type", &self.identify())
+            .field("res", &self.res)
+            .field("identify", &self.identify())
             .field("tsc_frequency", &self.tsc_frequency())
             .field("apic_frequency", &self.apic_frequency())
             .finish()
@@ -4275,7 +4651,7 @@ impl HypervisorInfo {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ExtendedFunctionInfo {
     max_eax_value: u32,
@@ -4310,7 +4686,8 @@ impl ExtendedFunctionInfo {
         val <= self.max_eax_value
     }
 
-    /// Retrieve processor brand string.
+    /// Retrieve processor brand string. For example
+    /// "11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz".
     pub fn processor_brand_string<'a>(&'a self) -> Option<&'a str> {
         if self.leaf_is_supported(EAX_EXTENDED_BRAND_STRING) {
             let brand_string_start = &self.data[2] as *const CpuIdResult as *const u8;
@@ -4466,6 +4843,31 @@ impl ExtendedFunctionInfo {
                 bits: self.data[1].edx,
             }
             .contains(ExtendedFunctionInfoEdx::I64BIT_MODE)
+    }
+}
+
+impl Debug for ExtendedFunctionInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ExtendedFunctionInfo")
+            .field("max_eax_value", &(self.max_eax_value as *const u32))
+            .field("data", &self.data)
+            .field("processor_brand_string", &self.processor_brand_string())
+            .field("extended_signature", &self.extended_signature())
+            .field("cache_line_size", &self.cache_line_size())
+            .field("l2_associativity", &self.l2_associativity())
+            .field("cache_size", &self.cache_size())
+            .field("physical_address_bits", &self.physical_address_bits())
+            .field("linear_address_bits", &self.linear_address_bits())
+            .field("has_invariant_tsc", &self.has_invariant_tsc())
+            .field("has_lahf_sahf", &self.has_lahf_sahf())
+            .field("has_lzcnt", &self.has_lzcnt())
+            .field("has_prefetchw", &self.has_prefetchw())
+            .field("has_syscall_sysret", &self.has_syscall_sysret())
+            .field("has_execute_disable", &self.has_execute_disable())
+            .field("has_1gib_pages", &self.has_1gib_pages())
+            .field("has_rdtscp", &self.has_rdtscp())
+            .field("has_64bit_mode", &self.has_64bit_mode())
+            .finish()
     }
 }
 

--- a/src/tests/i5_3337u.rs
+++ b/src/tests/i5_3337u.rs
@@ -179,7 +179,7 @@ fn thermal_power_features() {
         eax: ThermalPowerFeaturesEax { bits: 119 },
         ebx: 2,
         ecx: ThermalPowerFeaturesEcx { bits: 9 },
-        edx: 0,
+        _edx: 0,
     };
 
     assert!(tpfeatures.eax.contains(ThermalPowerFeaturesEax::DTS));
@@ -213,7 +213,7 @@ fn thermal_power_features() {
             | ThermalPowerFeaturesEax::HDC,
         ebx: 2,
         ecx: ThermalPowerFeaturesEcx::HW_COORD_FEEDBACK | ThermalPowerFeaturesEcx::ENERGY_BIAS_PREF,
-        edx: 0,
+        _edx: 0,
     };
 
     assert!(tpfeatures.has_dts());
@@ -237,12 +237,12 @@ fn thermal_power_features() {
 #[test]
 fn extended_features() {
     let tpfeatures = ExtendedFeatures {
-        eax: 0,
+        _eax: 0,
         ebx: ExtendedFeaturesEbx { bits: 641 },
         ecx: ExtendedFeaturesEcx { bits: 0 },
-        edx: 0,
+        _edx: 0,
     };
-    assert!(tpfeatures.eax == 0);
+    assert!(tpfeatures._eax == 0);
     assert!(tpfeatures.has_fsgsbase());
     assert!(!tpfeatures.has_tsc_adjust_msr());
     assert!(!tpfeatures.has_bmi1());
@@ -257,7 +257,7 @@ fn extended_features() {
     assert!(!tpfeatures.has_fpu_cs_ds_deprecated());
 
     let tpfeatures2 = ExtendedFeatures {
-        eax: 0,
+        _eax: 0,
         ebx: ExtendedFeaturesEbx::FSGSBASE
             | ExtendedFeaturesEbx::ADJUST_MSR
             | ExtendedFeaturesEbx::BMI1
@@ -274,7 +274,7 @@ fn extended_features() {
             | ExtendedFeaturesEbx::CLFLUSHOPT
             | ExtendedFeaturesEbx::PROCESSOR_TRACE,
         ecx: ExtendedFeaturesEcx { bits: 0 },
-        edx: 201326592,
+        _edx: 201326592,
     };
 
     assert!(tpfeatures2.has_fsgsbase());
@@ -305,7 +305,7 @@ fn performance_monitoring_info() {
     let pm = PerformanceMonitoringInfo {
         eax: 120587267,
         ebx: PerformanceMonitoringFeaturesEbx { bits: 0 },
-        ecx: 0,
+        _ecx: 0,
         edx: 1539,
     };
 
@@ -375,11 +375,11 @@ fn extended_state_info() {
         eax: ExtendedStateInfoXCR0Flags { bits: 7 },
         ebx: 832,
         ecx: 832,
-        edx: 0,
+        _edx: 0,
         eax1: 1,
         ebx1: 0,
         ecx1: ExtendedStateInfoXSSFlags { bits: 0 },
-        edx1: 0,
+        _edx1: 0,
     };
 
     assert!(es.xsave_area_size_enabled_features() == 832);
@@ -410,11 +410,11 @@ fn extended_state_info3() {
             | ExtendedStateInfoXCR0Flags::PKRU,
         ebx: 2688,
         ecx: 2696,
-        edx: 0,
+        _edx: 0,
         eax1: 15,
         ebx1: 2560,
         ecx1: ExtendedStateInfoXSSFlags::PT,
-        edx1: 0,
+        _edx1: 0,
     };
 
     assert!(esi.xcr0_supports_legacy_x87());
@@ -561,11 +561,11 @@ fn extended_state_info2() {
         eax: ExtendedStateInfoXCR0Flags { bits: 31 },
         ebx: 1088,
         ecx: 1088,
-        edx: 0,
+        _edx: 0,
         eax1: 15,
         ebx1: 960,
         ecx1: ExtendedStateInfoXSSFlags { bits: 256 },
-        edx1: 0,
+        _edx1: 0,
     };
 
     assert!(es.xcr0_supports_legacy_x87());
@@ -732,7 +732,7 @@ fn sgx_test() {
         read: Default::default(),
         eax: 1,
         ebx: 0,
-        ecx: 0,
+        _ecx: 0,
         edx: 9247,
         eax1: 54,
         ebx1: 0,


### PR DESCRIPTION
Hi! In my opinion this crate missed comprehensive debug impls for all structs. I changed all outputs for eax, ebx etc. to hex-based outputs and invoke all important methods for each struct and would like to propose you this MR.

**ONLY BLOCKER SO FAR**: Similar to the std vector, `vec::iter()` should print all elements of the iterator when debug-formatted. This is currently not possible, because I didn't found a nice way to solve this in code. 

Example debug output of `CpuId::new()` on my system with the new code:

```
CpuId {
    vendor: Intel,
    supported_leafs: 0x000000000000001b,
    vendor_info: Some(
        VendorInfo {
            ebx: 0x00000000756e6547,
            edx: 0x0000000049656e69,
            ecx: 0x000000006c65746e,
            brand_string: "GenuineIntel",
        },
    ),
    feature_info: Some(
        FeatureInfo {
            eax: 0x00000000000806c1,
            ebx: 0x0000000001100800,
            edx_ecx: SSE3 | PCLMULQDQ | DTES64 | MONITOR | DSCPL | VMX | EIST | TM2 | SSSE3 | FMA | CMPXCHG16B | PDCM | PCID | SSE41 | SSE42 | X2APIC | MOVBE | POPCNT | TSC_DEADLINE | AESNI | XSAVE | OSXSAVE | AVX | F16C | RDRAND | FPU | VME | DE | PSE | TSC | MSR | PAE | MCE | CX8 | APIC | SEP | MTRR | PGE | MCA | CMOV | PAT | PSE36 | CLFSH | DS | ACPI | MMX | FXSR | SSE | SSE2 | SS | HTT | TM | PBE | 0x0x4800,
        },
    ),
    cache_info: Some(
        CacheInfoIter {
            eax: 0x0000000000feff01,
            ebx: 0x00000000000000f0,
            ecx: 0x0000000000000000,
            edx: 0x0000000000000000,
        },
    ),
    processor_serial: Some(
        ProcessorSerial {
            ecx: 0x0000000000000000,
            edx: 0x0000000000000000,
            serial_lower: 0,
            serial_middle: 0,
            serial_middle: 0,
        },
    ),
    cache_parameters: Some(
        CacheParametersIter,
    ),
    monitor_mwait_info: Some(
        MonitorMwaitInfo {
            eax: 0x0000000000000040,
            ebx: 0x0000000000000040,
            ecx: 0x0000000000000003,
            edx: 0x0000000011121020,
            smallest_monitor_line: 64,
            largest_monitor_line: 64,
            extensions_supported: true,
            interrupts_as_break_event: true,
            supported_c0_states: 0,
            supported_c1_states: 2,
            supported_c2_states: 0,
            supported_c3_states: 1,
            supported_c4_states: 2,
            supported_c5_states: 1,
            supported_c6_states: 1,
            supported_c7_states: 1,
        },
    ),
    thermal_power_info: Some(
        ThermalPowerInfo {
            eax: DTS | TURBO_BOOST | ARAT | PLN | ECMD | PTM | HWP | HWP_NOTIFICATION | HWP_ACTIVITY_WINDOW | HWP_ENERGY_PERFORMANCE_PREFERENCE | HWP_PACKAGE_LEVEL_REQUEST | HDC | TURBO_BOOST_3 | HWP_CAPABILITIES | HWP_PECI_OVERRIDE | FLEXIBLE_HWP | HWP_REQUEST_MSR_FAST_ACCESS | IGNORE_IDLE_PROCESSOR_HWP_REQUEST,
            ebx: 0x0000000000000002,
            ecx: HW_COORD_FEEDBACK | ENERGY_BIAS_PREF,
            edx: 0x0000000000000000,
        },
    ),
    extended_feature_info: Some(
        ExtendedFeatures {
            eax: 0x0000000000000000,
            ebx: FSGSBASE | ADJUST_MSR | BMI1 | AVX2 | FDP | SMEP | BMI2 | REP_MOVSB_STOSB | INVPCID | DEPRECATE_FPU_CS_DS | RDTA | AVX512F | AVX512DQ | RDSEED | ADX | SMAP | AVX512_IFMA | CLFLUSHOPT | CLWB | PROCESSOR_TRACE | AVX512CD | SHA | AVX512BW | AVX512VL,
            ecx: AVX512VBMI | UMIP | PKU | OSPKE | RDPID | 0x0x18805fc0,
            edx: 0x00000000fc100510,
        },
    ),
    direct_cache_access_info: Some(
        DirectCacheAccessInfo {
            eax: 0x0000000000000000,
            dca_cap_value: 0,
        },
    ),
    performance_monitoring_info: Some(
        PerformanceMonitoringInfo {
            eax: 0x0000000008300805,
            eax: (empty),
            ecx: 0x000000000000000f,
            edx: 0x0000000000008604,
            version_id: 5,
            number_of_counters: 8,
            counter_bit_width: 48,
            ebx_length: 8,
            fixed_function_counters: 4,
            fixed_function_counters_bit_width: 48,
        },
    ),
    extended_topology_info: Some(
        ExtendedTopologyIter,
    ),
    extended_state_info: Some(
        ExtendedStateInfo {
            eax: LEGACY_X87 | SSE128 | AVX256 | AVX512_OPMASK | AVX512_ZMM_HI256 | AVX512_ZMM_HI16 | PKRU,
            ebx: 0x0000000000000a88,
            ecx: 0x0000000000000a88,
            edx: 0x0000000000000000,
            eax1: 0x000000000000000f,
            ebx1: 0x0000000000000988,
            ecx1: PT | HDC | 0x0x1800,
            edx1: 0x0000000000000000,
        },
    ),
    rdt_monitoring_info: Some(
        RdtMonitoringInfo {
            ebx: 0x0000000000000000,
            edx: 0x0000000000000000,
            rmid_range: 0,
            l3_monitoring: None,
        },
    ),
    rdt_allocation_info: Some(
        RdtAllocationInfo {
            ebx: 0x0000000000000004,
            l3_cat: None,
            l2_cat: Some(
                L2CatInfo {
                    eax: 0x0000000000000013,
                    ebx: 0x0000000000000000,
                    edx: 0x0000000000000007,
                    capacity_mask_length: 20,
                    isolation_bitmap: 0,
                    highest_cos: 7,
                },
            ),
            memory_bandwidth_allocation: Some(
                MemBwAllocationInfo {
                    eax: 0x0000000000000000,
                    ecx: 0x0000000000000000,
                    edx: 0x0000000000000000,
                    max_hba_throttling: 1,
                    highest_cos: 0,
                },
            ),
        },
    ),
    sgx_info: None,
    processor_trace_info: Some(
        ProcessorTraceInfo {
            eax: 0x0000000000000001,
            ebx: 0x000000000000004f,
            ecx: 0x0000000000000007,
            edx: 0x0000000000000000,
            leaf1: Some(
                CpuIdResult {
                    eax: 0x0000000002490002,
                    ebx: 0x00000000003f1fff,
                    ecx: 0x0000000000000000,
                    edx: 0x0000000000000000,
                },
            ),
            configurable_address_ranges: 0x0000000000000002,
            supported_mtc_period_encodings: 0x0000000000000249,
            supported_cycle_threshold_value_encodings: 0x0000000000001fff,
            supported_psb_frequency_encodings: 0x000000000000003f,
        },
    ),
    tsc_info: Some(
        TscInfo {
            eax: 0x0000000000000002,
            ebx: 0x0000000000000092,
            ecx: 0x000000000249f000,
            denominator: 2,
            numerator: 146,
            nominal_frequency: 38400000,
            tsc_frequency: Some(
                2803200000,
            ),
        },
    ),
    processor_frequency_info: Some(
        ProcessorFrequencyInfo {
            eax: 0x0000000000000af0,
            ebx: 0x000000000000125c,
            ecx: 0x0000000000000064,
            processor_base_frequency: 2800,
            processor_max_frequency: 4700,
            bus_frequency: 100,
        },
    ),
    deterministic_address_translation_info: Some(
        DatIter {
            read: CpuIdReader {
                cpuid_fn: 0x000055962cfc5fd0,
            },
            current: 0,
            count: 8,
        },
    ),
    soc_vendor_info: Some(
        SoCVendorInfo {
            eax: 0x0000000000000000,
            ebx: 0x0000000000000000,
            ecx: 0x0000000000000000,
            edx: 0x0000000000000000,
            soc_vendor_id: 0,
            project_id: 0,
            stepping_id: 0,
            vendor_brand: None,
            vendor_attributes: None,
        },
    ),
    hypervisor_info: None,
    extended_function_info: Some(
        ExtendedFunctionInfo {
            max_eax_value: 0x0000000000000008,
            data: [
                CpuIdResult {
                    eax: 0x0000000080000008,
                    ebx: 0x0000000000000000,
                    ecx: 0x0000000000000000,
                    edx: 0x0000000000000000,
                },
                CpuIdResult {
                    eax: 0x0000000000000000,
                    ebx: 0x0000000000000000,
                    ecx: 0x0000000000000121,
                    edx: 0x000000002c100800,
                },
                CpuIdResult {
                    eax: 0x0000000068743131,
                    ebx: 0x000000006e654720,
                    ecx: 0x00000000746e4920,
                    edx: 0x0000000052286c65,
                },
                CpuIdResult {
                    eax: 0x000000006f432029,
                    ebx: 0x0000000054286572,
                    ecx: 0x000000006920294d,
                    edx: 0x0000000031312d37,
                },
                CpuIdResult {
                    eax: 0x0000000037473536,
                    ebx: 0x0000000032204020,
                    ecx: 0x000000004730382e,
                    edx: 0x0000000000007a48,
                },
                CpuIdResult {
                    eax: 0x0000000000000000,
                    ebx: 0x0000000000000000,
                    ecx: 0x0000000000000000,
                    edx: 0x0000000000000000,
                },
                CpuIdResult {
                    eax: 0x0000000000000000,
                    ebx: 0x0000000000000000,
                    ecx: 0x0000000001007040,
                    edx: 0x0000000000000000,
                },
                CpuIdResult {
                    eax: 0x0000000000000000,
                    ebx: 0x0000000000000000,
                    ecx: 0x0000000000000000,
                    edx: 0x0000000000000100,
                },
                CpuIdResult {
                    eax: 0x0000000000003027,
                    ebx: 0x0000000000000000,
                    ecx: 0x0000000000000000,
                    edx: 0x0000000000000000,
                },
            ],
            processor_brand_string: Some(
                "11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz",
            ),
            extended_signature: Some(
                0,
            ),
            cache_line_size: Some(
                64,
            ),
            l2_associativity: Some(
                Unknown,
            ),
            cache_size: Some(
                256,
            ),
            physical_address_bits: Some(
                39,
            ),
            linear_address_bits: Some(
                48,
            ),
            has_invariant_tsc: true,
            has_lahf_sahf: true,
            has_lzcnt: true,
            has_prefetchw: true,
            has_syscall_sysret: true,
            has_execute_disable: true,
            has_1gib_pages: true,
            has_rdtscp: true,
            has_64bit_mode: true,
        },
    ),
    memory_encryption_info: None,
}
```

What do you think? I think this would be pretty useful. I typically like to debug-format structs to see what I can get from them. I think others will benefit from this as well.


PS: I don't know why CI is failing?!