### PR TITLE
AMD support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Remove `has_rdseet` function (deprecated since 3.2), clients should use the correctly named `has_rdseed` function instead (**breaking change**).
  - Updated Debug trait for SGX iterators.
  - Make CpuId derive Clone and Copy ([#53](https://github.com/gz/rust-cpuid/pull/53))
- - Marked `get_extended_function_info` as deprecated. Use xxx instead.
+ - Marked `get_extended_function_info` as deprecated. Use `get_processor_brand_string`, `xxx` instead.
  - Marked `deterministic_address_translation_info` as deprecated. Use `get_deterministic_address_translation_info` instead.
  - Improved documentation in some places by adding leaf numbers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased v10]
 
 - Removed `get_extended_function_info` with new AMD support: Use
-  `get_processor_brand_string`, `get_extended_processor_and_feature_identifiers`,
-  `get_l1_cache_and_tlb_info`, `get_l2_l3_cache_and_tlb_info` instead. (**breaking
-  change**)
+  `get_processor_brand_string`,
+  `get_extended_processor_and_feature_identifiers`, `get_l1_cache_and_tlb_info`,
+  `get_l2_l3_cache_and_tlb_info`, `get_advanced_power_mgmt_info`,
+  `get_processor_capacity_feature_info` instead. (**breaking change**)
 - Removed `deterministic_address_translation_info`. Use
   `get_deterministic_address_translation_info` instead. (**breaking change**)
 - Renamed `model_id` and `family_id` to `base_model_id` and `base_family_id` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased v10]
 
- - Removed `get_extended_function_info` with new AMD support: Use `get_processor_brand_string`, `get_extended_processor_and_feature_identifiers`, `xxx` instead. (**breaking change**)
- - Removed `deterministic_address_translation_info`. Use `get_deterministic_address_translation_info` instead. (**breaking change**)
- - Renamed `model_id` and `family_id` to `base_model_id` and `base_family_id` in `FeatureInfo`. Added new `family_id` and `model_id` functions
-   that compute the actual model and family according to the spec by joining base and extended family/model. (**breaking change**)
- - Extend Hypervisor enum with more variants ([#50](https://github.com/gz/rust-cpuid/pull/50)) (**breaking change**)
- - Remove `has_rdseet` function (deprecated since 3.2), clients should use the correctly named `has_rdseed` function instead (**breaking change**).
+- Removed `get_extended_function_info` with new AMD support: Use
+  `get_processor_brand_string`, `get_extended_processor_and_feature_identifiers`,
+  `get_l1_cache_and_tlb_info`, `get_l2_l3_cache_and_tlb_info` instead. (**breaking
+  change**)
+- Removed `deterministic_address_translation_info`. Use
+  `get_deterministic_address_translation_info` instead. (**breaking change**)
+- Renamed `model_id` and `family_id` to `base_model_id` and `base_family_id` in
+  `FeatureInfo`. Added new `family_id` and `model_id` functions that compute the actual
+  model and family according to the spec by joining base and extended family/model.
+  (**breaking change**)
+- Extend Hypervisor enum with more variants
+  ([#50](https://github.com/gz/rust-cpuid/pull/50)) (**breaking change**)
+- Remove `has_rdseet` function (deprecated since 3.2), clients should use the correctly
+  named `has_rdseed` function instead (**breaking change**).
  - Updated Debug trait for SGX iterators.
- - Make CpuId derive Clone and Copy ([#53](https://github.com/gz/rust-cpuid/pull/53))
- - Improved documentation in some places by adding leaf numbers.
- - Added AMD support for leafs 0x8000_0001, 0x8000_0006
- - Updated AMD leaf 0x8000_001f (Encrypted Memory) to latest manual.
+- Make CpuId derive Clone and Copy ([#53](https://github.com/gz/rust-cpuid/pull/53))
+- Improved documentation in some places by adding leaf numbers.
+- Added AMD support for leafs 0x8000_0001, 0x8000_0006
+- Updated AMD leaf 0x8000_001f (Encrypted Memory) to latest manual.
  
 ## [9.1.1] - 2021-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased v10]
 
- - Removed `get_extended_function_info` with new AMD support: Use `get_processor_brand_string`, `xxx` instead. (**breaking change**)
+ - Removed `get_extended_function_info` with new AMD support: Use `get_processor_brand_string`, `get_extended_processor_and_feature_identifiers`, `xxx` instead. (**breaking change**)
  - Removed `deterministic_address_translation_info`. Use `get_deterministic_address_translation_info` instead. (**breaking change**)
  - Renamed `model_id` and `family_id` to `base_model_id` and `base_family_id` in `FeatureInfo`. Added new `family_id` and `model_id` functions
    that compute the actual model and family according to the spec by joining base and extended family/model. (**breaking change**)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,27 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased v10]
 
-- Removed `get_extended_function_info` with new AMD support: Use
+### Breaking changes for v10
+
+- Removed `get_extended_function_info` / `ExtendedFunctionInfo` due to added AMD support: Use
   `get_processor_brand_string`,
   `get_extended_processor_and_feature_identifiers`, `get_l1_cache_and_tlb_info`,
   `get_l2_l3_cache_and_tlb_info`, `get_advanced_power_mgmt_info`,
-  `get_processor_capacity_feature_info` instead. (**breaking change**)
-- Removed `deterministic_address_translation_info`. Use
-  `get_deterministic_address_translation_info` instead. (**breaking change**)
+  `get_processor_capacity_feature_info` instead:
+
+  Migration guide for replacing `get_extended_function_info` / `ExtendedFunctionInfo`:
+
+  | <= v9                      | >= v10                                                                         |
+  | -------------------------- | ------------------------------------------------------------------------------ |
+  | `processor_brand_string()` | `CpuId.get_processor_brand_string`                                             |
+  | `cache_line_size()`        | `Cpuid.get_l2_l3_cache_and_tlb_info().l2cache_line_size()`                     |
+  | `l2_associativity()`       | `Cpuid.get_l2_l3_cache_and_tlb_info().l2cache_associativity()`                 |
+  | `cache_size()`             | `Cpuid.get_l2_l3_cache_and_tlb_info().l2cache_size()`                          |
+  | `physical_address_bits()`  | `CpuId.get_processor_capacity_feature_info().physical_address_bits()`          |
+  | `linear_address_bits()`    | `CpuId.get_processor_capacity_feature_info().linear_address_bits()`            |
+  | `has_invariant_tsc()`      | `CpuId.get_advanced_power_mgmt_info.has_invariant_tsc()`                       |
+  | `has_lahf_sahf()`          | `CpuId.get_extended_processor_and_feature_identifiers().has_lahf_sahf()`       |
+  | `has_lzcnt()`              | `CpuId.get_extended_processor_and_feature_identifiers().has_lzcnt()`           |
+  | `has_prefetchw()`          | `CpuId.get_extended_processor_and_feature_identifiers().has_prefetchw()`       |
+  | `has_syscall_sysret()`     | `CpuId.get_extended_processor_and_feature_identifiers().has_syscall_sysret()`  |
+  | `has_execute_disable()`    | `CpuId.get_extended_processor_and_feature_identifiers().has_execute_disable()` |
+  | `has_1gib_pages()`         | `CpuId.get_extended_processor_and_feature_identifiers().has_1gib_pages()`      |
+  | `has_rdtscp()`             | `CpuId.get_extended_processor_and_feature_identifiers().has_rdtscp()`          |
+  | `has_64bit_mode()`         | `CpuId.get_extended_processor_and_feature_identifiers().has_64bit_mode()`      |
+
+- Removed `CpuId.deterministic_address_translation_info`. Use
+  `CpuId.get_deterministic_address_translation_info` instead.
 - Renamed `model_id` and `family_id` to `base_model_id` and `base_family_id` in
   `FeatureInfo`. Added new `family_id` and `model_id` functions that compute the actual
   model and family according to the spec by joining base and extended family/model.
-  (**breaking change**)
 - Extend Hypervisor enum with more variants
-  ([#50](https://github.com/gz/rust-cpuid/pull/50)) (**breaking change**)
+  ([#50](https://github.com/gz/rust-cpuid/pull/50))
 - Remove `has_rdseet` function (deprecated since 3.2), clients should use the correctly
-  named `has_rdseed` function instead (**breaking change**).
- - Updated Debug trait for SGX iterators.
+  named `has_rdseed` function instead.
+
+  Migration guide for `cpuid.get_feature_info()`:
+
+  | <= v9           | >= v10          |
+  | -----------     | -----------     |
+  | `has_rdseet()`  | `has_rdseed()`  |
+
+### Changes
+
+- Updated Debug trait for SGX iterators.
 - Make CpuId derive Clone and Copy ([#53](https://github.com/gz/rust-cpuid/pull/53))
 - Improved documentation in some places by adding leaf numbers.
-- Added AMD support for leafs 0x8000_0001, 0x8000_0006
 - Updated AMD leaf 0x8000_001f (Encrypted Memory) to latest manual.
- 
+
+### Added
+
+- Added AMD support for leaf 0x8000_0001
+- Added AMD support for leaf 0x8000_0005
+- Added AMD support for leaf 0x8000_0006
+- Added AMD support for leaf 0x8000_0007
+- Added AMD support for leaf 0x8000_0008
+
 ## [9.1.1] - 2021-07-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Updated Debug trait for SGX iterators.
  - Make CpuId derive Clone and Copy ([#53](https://github.com/gz/rust-cpuid/pull/53))
  - Improved documentation in some places by adding leaf numbers.
+ - Added AMD support for leafs 0x8000_0001, 0x8000_0006
+ - Updated AMD leaf 0x8000_001f (Encrypted Memory) to latest manual.
  
 ## [9.1.1] - 2021-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased v10]
 
+ - Removed `get_extended_function_info` with new AMD support: Use `get_processor_brand_string`, `xxx` instead. (**breaking change**)
+ - Removed `deterministic_address_translation_info`. Use `get_deterministic_address_translation_info` instead. (**breaking change**)
+ - Renamed `model_id` and `family_id` to `base_model_id` and `base_family_id` in `FeatureInfo`. Added new `family_id` and `model_id` functions
+   that compute the actual model and family according to the spec by joining base and extended family/model. (**breaking change**)
  - Extend Hypervisor enum with more variants ([#50](https://github.com/gz/rust-cpuid/pull/50)) (**breaking change**)
  - Remove `has_rdseet` function (deprecated since 3.2), clients should use the correctly named `has_rdseed` function instead (**breaking change**).
  - Updated Debug trait for SGX iterators.
  - Make CpuId derive Clone and Copy ([#53](https://github.com/gz/rust-cpuid/pull/53))
- - Marked `get_extended_function_info` as deprecated. Use `get_processor_brand_string`, `xxx` instead.
- - Marked `deterministic_address_translation_info` as deprecated. Use `get_deterministic_address_translation_info` instead.
  - Improved documentation in some places by adding leaf numbers.
-
+ 
 ## [9.1.1] - 2021-07-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 A library to parse the x86 CPUID instruction, written in rust with no external dependencies. The implementation closely resembles the Intel CPUID manual description. The library does only depend on libcore.
 
-The code should be in sync with the latest March 2018 revision of the Intel Architectures Software Developer’s Manual.
+- For Intel platforms: The code should be in sync with the March 2018 revision of the Intel Architectures SDM.
+- For AMD platforms it should be in sync with the AMD64 systems manual no. 24594,  Revision 3.32 (March 2021).
 
 ## Library usage
 

--- a/examples/cpu.rs
+++ b/examples/cpu.rs
@@ -14,10 +14,10 @@ fn main() {
 
     println!(
         "CPU Model is: {}",
-        cpuid.get_extended_function_info().as_ref().map_or_else(
-            || "n/a",
-            |extfuninfo| extfuninfo.processor_brand_string().unwrap_or("unreadable"),
-        )
+        cpuid
+            .get_processor_brand_string()
+            .as_ref()
+            .map_or_else(|| "n/a", |pbs| pbs.as_str())
     );
 
     println!(
@@ -41,11 +41,13 @@ fn main() {
         || println!("Family: n/a\nExtended Family: n/a\nModel: n/a\nExtended Model: n/a\nStepping: n/a\nBrand Index: n/a"),
         |finfo| {
             println!(
-                "Family: {}\nExtended Family: {}\nModel: {}\nExtended Model: {}\nStepping: {}\nBrand Index: {}",
-                finfo.family_id(),
+                "Base Family: {}\nExtended Family: {}\nFamily: {}\nBase Model: {}\nExtended Model: {}\nModel: {}\nStepping: {}\nBrand Index: {}",
+                finfo.base_family_id(),
                 finfo.extended_family_id(),
-                finfo.model_id(),
+                finfo.family_id(),
+                finfo.base_model_id(),
                 finfo.extended_model_id(),
+                finfo.model_id(),
                 finfo.stepping_id(),
                 finfo.brand_index(),
             );

--- a/examples/topology.rs
+++ b/examples/topology.rs
@@ -163,14 +163,9 @@ fn enumerate_with_legacy_leaf_1_4() {
 fn main() {
     let cpuid = CpuId::new();
 
-    cpuid.get_extended_function_info().map_or_else(
-        || println!("Couldn't find processor serial number."),
-        |extfuninfo| {
-            println!(
-                "CPU Model is: {}",
-                extfuninfo.processor_brand_string().unwrap_or("Unknown CPU")
-            )
-        },
+    cpuid.get_processor_brand_string().map_or_else(
+        || println!("CPU model identifier not available."),
+        |pbs| println!("CPU Model is: {}", pbs.as_str()),
     );
     cpuid.get_extended_topology_info().map_or_else(
         || println!("No topology information available."),

--- a/examples/tsc_frequency.rs
+++ b/examples/tsc_frequency.rs
@@ -26,7 +26,7 @@ fn main() {
         .map_or(false, |finfo| finfo.has_tsc());
 
     let has_invariant_tsc = cpuid
-        .get_extended_function_info()
+        .get_advanced_power_mgmt_info()
         .map_or(false, |efinfo| efinfo.has_invariant_tsc());
 
     let tsc_frequency_hz = cpuid.get_tsc_info().map(|tinfo| {

--- a/src/bin/cpuid.rs
+++ b/src/bin/cpuid.rs
@@ -77,7 +77,7 @@ fn main() {
         println!("Processor Frequency");
         println!("{:?}", info);
     }
-    if let Some(dats) = cpuid.deterministic_address_translation_info() {
+    if let Some(dats) = cpuid.get_deterministic_address_translation_info() {
         println!("Deterministic Address Translation");
         for dat in dats {
             println!("{:?}", dat);
@@ -87,8 +87,8 @@ fn main() {
         println!("SoC Vendor Info");
         println!("{:?}", info);
     }
-    if let Some(info) = cpuid.get_extended_function_info() {
-        println!("Extended Function Info");
+    if let Some(info) = cpuid.get_processor_brand_string() {
+        println!("Processor Brand String");
         println!("{:?}", info);
     }
     if let Some(info) = cpuid.get_memory_encryption_info() {

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -1,0 +1,46 @@
+//! Data-structures / interpretation for extended leafs (>= 0x8000_0000)
+use core::fmt::{Debug, Formatter};
+use core::mem::size_of;
+use core::slice;
+use core::str;
+
+use crate::CpuIdResult;
+
+/// ASCII string up to 48 characters in length corresponding to the processor name.
+/// (LEAF = 0x8000_0002..=0x8000_0004)
+pub struct ProcessorBrandString {
+    data: [CpuIdResult; 3],
+}
+
+impl ProcessorBrandString {
+    pub(crate) fn new(data: [CpuIdResult; 3]) -> Self {
+        Self { data }
+    }
+
+    /// Return the processor brand string as a rust string.
+    ///
+    /// For example:
+    /// "11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz".
+    pub fn as_str(&self) -> &str {
+        // Safety: CpuIdResult is laid out with repr(C), and the array
+        // self.data contains 3 continguous elements.
+        let slice: &[u8] = unsafe {
+            slice::from_raw_parts(
+                self.data.as_ptr() as *const u8,
+                self.data.len() * size_of::<CpuIdResult>(),
+            )
+        };
+
+        // Brand terminated at nul byte or end, whichever comes first.
+        let slice = slice.split(|&x| x == 0).next().unwrap();
+        str::from_utf8(slice).unwrap_or("Invalid Processor Brand String")
+    }
+}
+
+impl Debug for ProcessorBrandString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ProcessorBrandString")
+            .field("as_str", &self.as_str())
+            .finish()
+    }
+}

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -87,14 +87,193 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SVM)
     }
 
+    /// Extended APIC space. This bit indicates the presence of extended APIC register space starting at offset 400h from the “APIC Base Address Register,” as specified in the BKDG.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_ext_apic_space(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::EXT_APIC_SPACE)
+    }
+
+    /// LOCK MOV CR0 means MOV CR8. See “MOV(CRn)” in APM3.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_alt_mov_cr8(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::ALTMOVCR8)
+    }
+
     /// Is LZCNT available?
     pub fn has_lzcnt(&self) -> bool {
         self.ecx.contains(ExtendedFunctionInfoEcx::LZCNT)
     }
 
+    /// XTRQ, INSERTQ, MOVNTSS, and MOVNTSD instruction support.
+    /// See “EXTRQ”, “INSERTQ”, “MOVNTSS”, and “MOVNTSD” in APM4.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_sse4a(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SSE4A)
+    }
+
+    /// Misaligned SSE mode. See “Misaligned Access Support Added for SSE Instructions” in APM1.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_misaligned_sse_mode(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::MISALIGNSSE)
+    }
+
     /// Is PREFETCHW available?
+    ///
+    /// # AMD
+    /// PREFETCH and PREFETCHW instruction support.
     pub fn has_prefetchw(&self) -> bool {
         self.ecx.contains(ExtendedFunctionInfoEcx::PREFETCHW)
+    }
+
+    /// Indicates OS-visible workaround support
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_osvw(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::OSVW)
+    }
+
+    /// Instruction based sampling.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_ibs(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::IBS)
+    }
+
+    /// Extended operation support.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_xop(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::XOP)
+    }
+
+    /// SKINIT and STGI are supported.
+    ///
+    /// Indicates support for SKINIT and STGI, independent of
+    /// the value of MSRC000_0080[SVME].
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_skinit(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SKINIT)
+    }
+
+    /// Watchdog timer support.
+    ///
+    /// Indicates support for MSRC001_0074.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_wdt(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::WDT)
+    }
+
+    /// Lightweight profiling support
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_lwp(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::LWP)
+    }
+
+    /// Four-operand FMA instruction support.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_fma4(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::FMA4)
+    }
+
+    /// Trailing bit manipulation instruction support. .
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_tbm(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::TBM)
+    }
+
+    /// Topology extensions support.
+    ///
+    /// Indicates support for CPUID Fn8000_001D_EAX_x[N:0]-CPUID Fn8000_001E_EDX.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_topology_extensions(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::TOPEXT)
+    }
+
+    /// Processor performance counter extensions support.
+    ///
+    /// Indicates support for MSRC001_020[A,8,6,4,2,0] and MSRC001_020[B,9,7,5,3,1].
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_perf_cntr_extensions(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFCTREXT)
+    }
+
+    /// NB performance counter extensions support.
+    ///
+    /// Indicates support for MSRC001_024[6,4,2,0] and MSRC001_024[7,5,3,1].
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_nb_perf_cntr_extensions(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFCTREXTNB)
+    }
+
+    /// Data access breakpoint extension.
+    ///
+    /// Indicates support for MSRC001_1027 and MSRC001_101[B:9].
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_data_access_bkpt_extension(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::DATABRKPEXT)
+    }
+
+    /// Performance time-stamp counter.
+    ///
+    /// Indicates support for MSRC001_0280 [Performance Time Stamp Counter].
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_perf_tsc(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFTSC)
+    }
+
+    /// Support for L3 performance counter extension.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_perf_cntr_llc_extensions(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFCTREXTLLC)
+    }
+
+    /// Support for MWAITX and MONITORX instructions.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_monitorx_mwaitx(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::MONITORX)
+    }
+
+    /// Breakpoint Addressing masking extended to bit 31. .
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_addr_mask_extension(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::ADDRMASKEXT)
     }
 
     /// Are fast system calls available.

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -7,6 +7,9 @@ use core::str;
 use crate::{get_bits, CpuIdResult, Vendor};
 
 /// Extended Processor and Processor Feature Identifiers (LEAF=0x8000_0001)
+///
+/// # Platforms
+/// ✅ AMD 🟡 Intel
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ExtendedProcessorFeatureIdentifiers {
     vendor: Vendor,
@@ -36,91 +39,103 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// (use `CpuId.get_feature_info` instead)
     ///
     /// # Intel
-    /// Vague mention of "Extended Processor Signature", not clear what it's supposed to represent.
+    /// Vague mention of "Extended Processor Signature", not clear what it's supposed to
+    /// represent.
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn extended_signature(&self) -> u32 {
         self.eax
     }
 
     /// Returns package type on AMD.
     ///
-    /// # Intel
-    /// This field is not used (reseved).
+    /// Package type. If (Family[7:0] >= 10h), this field is valid. If (Family[7:0]<10h),
+    /// this field is reserved
     ///
-    /// # AMD
-    /// Package type. If (Family[7:0] >= 10h), this field is valid.
-    /// If (Family[7:0]<10h), this field is reserved
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved)
     pub fn pkg_type(&self) -> u32 {
         get_bits(self.ebx, 28, 31)
     }
 
     /// Returns brand ID on AMD.
     ///
-    /// # Intel
-    /// This field is not used (reserved).
+    /// This field, in conjunction with CPUID LEAF=0x0000_0001_EBX[8BitBrandId], and used
+    /// by firmware to generate the processor name string.
     ///
-    /// # AMD
-    /// This field, in conjunction with CPUID
-    /// LEAF=0x0000_0001_EBX[8BitBrandId], and used by firmware to generate the
-    /// processor name string.
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved)
     pub fn brand_id(&self) -> u32 {
         get_bits(self.ebx, 0, 15)
     }
 
     /// Is LAHF/SAHF available in 64-bit mode?
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn has_lahf_sahf(&self) -> bool {
         self.ecx.contains(ExtendedFunctionInfoEcx::LAHF_SAHF)
     }
 
-    /// Check support for 64-bit mode.
+    /// Check support legacy cmp.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_cmp_legacy(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::CMP_LEGACY)
     }
 
     /// Secure virtual machine supported.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_svm(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SVM)
     }
 
-    /// Extended APIC space. This bit indicates the presence of extended APIC register space starting at offset 400h from the “APIC Base Address Register,” as specified in the BKDG.
+    /// Extended APIC space.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// This bit indicates the presence of extended APIC register space starting at offset
+    /// 400h from the “APIC Base Address Register,” as specified in the BKDG.
+    ///
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_ext_apic_space(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::EXT_APIC_SPACE)
     }
 
     /// LOCK MOV CR0 means MOV CR8. See “MOV(CRn)” in APM3.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_alt_mov_cr8(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::ALTMOVCR8)
     }
 
     /// Is LZCNT available?
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn has_lzcnt(&self) -> bool {
         self.ecx.contains(ExtendedFunctionInfoEcx::LZCNT)
     }
 
     /// XTRQ, INSERTQ, MOVNTSS, and MOVNTSD instruction support.
-    /// See “EXTRQ”, “INSERTQ”, “MOVNTSS”, and “MOVNTSD” in APM4.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// See “EXTRQ”, “INSERTQ”,“MOVNTSS”, and “MOVNTSD” in APM4.
+    ///
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_sse4a(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SSE4A)
     }
 
-    /// Misaligned SSE mode. See “Misaligned Access Support Added for SSE Instructions” in APM1.
+    /// Misaligned SSE mode. See “Misaligned Access Support Added for SSE Instructions” in
+    /// APM1.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_misaligned_sse_mode(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::MISALIGNSSE)
     }
@@ -129,41 +144,44 @@ impl ExtendedProcessorFeatureIdentifiers {
     ///
     /// # AMD
     /// PREFETCH and PREFETCHW instruction support.
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn has_prefetchw(&self) -> bool {
         self.ecx.contains(ExtendedFunctionInfoEcx::PREFETCHW)
     }
 
     /// Indicates OS-visible workaround support
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_osvw(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::OSVW)
     }
 
     /// Instruction based sampling.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_ibs(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::IBS)
     }
 
     /// Extended operation support.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_xop(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::XOP)
     }
 
     /// SKINIT and STGI are supported.
     ///
-    /// Indicates support for SKINIT and STGI, independent of
-    /// the value of MSRC000_0080[SVME].
+    /// Indicates support for SKINIT and STGI, independent of the value of
+    /// MSRC000_0080[SVME].
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_skinit(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SKINIT)
     }
@@ -172,32 +190,32 @@ impl ExtendedProcessorFeatureIdentifiers {
     ///
     /// Indicates support for MSRC001_0074.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_wdt(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::WDT)
     }
 
     /// Lightweight profiling support
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_lwp(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::LWP)
     }
 
     /// Four-operand FMA instruction support.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_fma4(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::FMA4)
     }
 
     /// Trailing bit manipulation instruction support.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_tbm(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::TBM)
     }
@@ -206,8 +224,8 @@ impl ExtendedProcessorFeatureIdentifiers {
     ///
     /// Indicates support for CPUID Fn8000_001D_EAX_x[N:0]-CPUID Fn8000_001E_EDX.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_topology_extensions(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::TOPEXT)
     }
@@ -216,8 +234,8 @@ impl ExtendedProcessorFeatureIdentifiers {
     ///
     /// Indicates support for MSRC001_020[A,8,6,4,2,0] and MSRC001_020[B,9,7,5,3,1].
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_perf_cntr_extensions(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFCTREXT)
     }
@@ -226,8 +244,8 @@ impl ExtendedProcessorFeatureIdentifiers {
     ///
     /// Indicates support for MSRC001_024[6,4,2,0] and MSRC001_024[7,5,3,1].
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_nb_perf_cntr_extensions(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFCTREXTNB)
     }
@@ -236,8 +254,8 @@ impl ExtendedProcessorFeatureIdentifiers {
     ///
     /// Indicates support for MSRC001_1027 and MSRC001_101[B:9].
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_data_access_bkpt_extension(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::DATABRKPEXT)
     }
@@ -246,89 +264,104 @@ impl ExtendedProcessorFeatureIdentifiers {
     ///
     /// Indicates support for MSRC001_0280 [Performance Time Stamp Counter].
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_perf_tsc(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFTSC)
     }
 
     /// Support for L3 performance counter extension.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_perf_cntr_llc_extensions(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFCTREXTLLC)
     }
 
     /// Support for MWAITX and MONITORX instructions.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_monitorx_mwaitx(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::MONITORX)
     }
 
     /// Breakpoint Addressing masking extended to bit 31.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_addr_mask_extension(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::ADDRMASKEXT)
     }
 
     /// Are fast system calls available.
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn has_syscall_sysret(&self) -> bool {
         self.edx.contains(ExtendedFunctionInfoEdx::SYSCALL_SYSRET)
     }
 
     /// Is there support for execute disable bit.
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn has_execute_disable(&self) -> bool {
         self.edx.contains(ExtendedFunctionInfoEdx::EXECUTE_DISABLE)
     }
 
     /// AMD extensions to MMX instructions.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_mmx_extensions(&self) -> bool {
         self.vendor == Vendor::Amd && self.edx.contains(ExtendedFunctionInfoEdx::MMXEXT)
     }
 
     /// FXSAVE and FXRSTOR instruction optimizations.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_fast_fxsave_fxstor(&self) -> bool {
         self.vendor == Vendor::Amd && self.edx.contains(ExtendedFunctionInfoEdx::FFXSR)
     }
 
     /// Is there support for 1GiB pages.
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn has_1gib_pages(&self) -> bool {
         self.edx.contains(ExtendedFunctionInfoEdx::GIB_PAGES)
     }
 
     /// Check support for rdtscp instruction.
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn has_rdtscp(&self) -> bool {
         self.edx.contains(ExtendedFunctionInfoEdx::RDTSCP)
     }
 
     /// Check support for 64-bit mode.
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn has_64bit_mode(&self) -> bool {
         self.edx.contains(ExtendedFunctionInfoEdx::I64BIT_MODE)
     }
 
     /// 3DNow AMD extensions.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_amd_3dnow_extensions(&self) -> bool {
         self.vendor == Vendor::Amd && self.edx.contains(ExtendedFunctionInfoEdx::THREEDNOWEXT)
     }
 
     /// 3DNow extensions.
     ///
-    /// # Intel
-    /// This feature is unavailable on Intel CPUs (will return false).
+    /// # Platform
+    /// ✅ AMD ❌ Intel (will return false)
     pub fn has_3dnow(&self) -> bool {
         self.vendor == Vendor::Amd && self.edx.contains(ExtendedFunctionInfoEdx::THREEDNOW)
     }
@@ -399,6 +432,9 @@ bitflags! {
 
 /// ASCII string up to 48 characters in length corresponding to the processor name.
 /// (LEAF = 0x8000_0002..=0x8000_0004)
+///
+/// # Platforms
+/// ✅ AMD ✅ Intel
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ProcessorBrandString {
     data: [CpuIdResult; 3],
@@ -437,16 +473,456 @@ impl Debug for ProcessorBrandString {
     }
 }
 
-/// L1 Cache and TLB Information.
+/// L1 Cache and TLB Information (LEAF=0x8000_0005).
 ///
-/// # Intel
-/// This info is unavailable on Intel CPUs.
+/// # Availability
+/// ✅ AMD ❌ Intel (reserved=0)
+#[derive(PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct L1CacheTlbInfo {
-    data: CpuIdResult,
+    eax: u32,
+    ebx: u32,
+    ecx: u32,
+    edx: u32,
 }
 
 impl L1CacheTlbInfo {
     pub(crate) fn new(data: CpuIdResult) -> Self {
-        Self { data }
+        Self {
+            eax: data.eax,
+            ebx: data.ebx,
+            ecx: data.ecx,
+            edx: data.edx,
+        }
+    }
+
+    /// Data TLB associativity for 2-MB and 4-MB pages.
+    pub fn dtlb_2m_4m_associativity(&self) -> Associativity {
+        let assoc_bits = get_bits(self.eax, 24, 31) as u8;
+        Associativity::for_l1(assoc_bits)
+    }
+
+    /// Data TLB number of entries for 2-MB and 4-MB pages.
+    ///
+    /// The value returned is for the number of entries available for the 2-MB page size;
+    /// 4-MB pages require two 2-MB entries, so the number of entries available for the
+    /// 4-MB page size is one-half the returned value.
+    pub fn dtlb_2m_4m_size(&self) -> u8 {
+        get_bits(self.eax, 16, 23) as u8
+    }
+
+    /// Instruction TLB associativity for 2-MB and 4-MB pages.
+    pub fn itlb_2m_4m_associativity(&self) -> Associativity {
+        let assoc_bits = get_bits(self.eax, 8, 15) as u8;
+        Associativity::for_l1(assoc_bits)
+    }
+
+    /// Instruction TLB number of entries for 2-MB and 4-MB pages.
+    ///
+    /// The value returned is for the number of entries available for the 2-MB page size;
+    /// 4-MB pages require two 2-MB entries, so the number of entries available for the
+    /// 4-MB page size is one-half the returned value.
+    pub fn itlb_2m_4m_size(&self) -> u8 {
+        get_bits(self.eax, 0, 7) as u8
+    }
+
+    /// Data TLB associativity for 4K pages.
+    pub fn dtlb_4k_associativity(&self) -> Associativity {
+        let assoc_bits = get_bits(self.ebx, 24, 31) as u8;
+        Associativity::for_l1(assoc_bits)
+    }
+
+    /// Data TLB number of entries for 4K pages.
+    pub fn dtlb_4k_size(&self) -> u8 {
+        get_bits(self.ebx, 16, 23) as u8
+    }
+
+    /// Instruction TLB associativity for 4K pages.
+    pub fn itlb_4k_associativity(&self) -> Associativity {
+        let assoc_bits = get_bits(self.ebx, 8, 15) as u8;
+        Associativity::for_l1(assoc_bits)
+    }
+
+    /// Instruction TLB number of entries for 4K pages.
+    pub fn itlb_4k_size(&self) -> u8 {
+        get_bits(self.ebx, 0, 7) as u8
+    }
+
+    /// L1 data cache size in KB
+    pub fn dcache_size(&self) -> u8 {
+        get_bits(self.ecx, 24, 31) as u8
+    }
+
+    /// L1 data cache associativity.
+    pub fn dcache_associativity(&self) -> Associativity {
+        let assoc_bits = get_bits(self.ecx, 16, 23) as u8;
+        Associativity::for_l1(assoc_bits)
+    }
+
+    /// L1 data cache lines per tag.
+    pub fn dcache_lines_per_tag(&self) -> u8 {
+        get_bits(self.ecx, 8, 15) as u8
+    }
+
+    /// L1 data cache line size in bytes.
+    pub fn dcache_line_size(&self) -> u8 {
+        get_bits(self.ecx, 0, 7) as u8
+    }
+
+    /// L1 instruction cache size in KB
+    pub fn icache_size(&self) -> u8 {
+        get_bits(self.edx, 24, 31) as u8
+    }
+
+    /// L1 instruction cache associativity.
+    pub fn icache_associativity(&self) -> Associativity {
+        let assoc_bits = get_bits(self.edx, 16, 23) as u8;
+        Associativity::for_l1(assoc_bits)
+    }
+
+    /// L1 instruction cache lines per tag.
+    pub fn icache_lines_per_tag(&self) -> u8 {
+        get_bits(self.edx, 8, 15) as u8
+    }
+
+    /// L1 instruction cache line size in bytes.
+    pub fn icache_line_size(&self) -> u8 {
+        get_bits(self.edx, 0, 7) as u8
+    }
+}
+
+/// L2 Cache and TLB Information (LEAF=0x8000_0006).
+///
+/// # Availability
+/// ✅ AMD 🟡 Intel
+#[derive(PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct L2And3CacheTlbInfo {
+    eax: u32,
+    ebx: u32,
+    ecx: u32,
+    edx: u32,
+}
+
+impl L2And3CacheTlbInfo {
+    /// L2 Data TLB associativity for 2-MB and 4-MB pages.
+    ///
+    /// # Availability
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn dtlb_2m_4m_associativity(&self) -> Associativity {
+        let assoc_bits = get_bits(self.eax, 28, 31) as u8;
+        Associativity::for_l2(assoc_bits)
+    }
+
+    /// L2 Data TLB number of entries for 2-MB and 4-MB pages.
+    ///
+    /// The value returned is for the number of entries available for the 2-MB page size;
+    /// 4-MB pages require two 2-MB entries, so the number of entries available for the
+    /// 4-MB page size is one-half the returned value.
+    ///
+    /// # Availability
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn dtlb_2m_4m_size(&self) -> u16 {
+        get_bits(self.eax, 16, 27) as u16
+    }
+
+    /// L2 Instruction TLB associativity for 2-MB and 4-MB pages.
+    ///
+    /// # Availability
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn itlb_2m_4m_associativity(&self) -> Associativity {
+        let assoc_bits = get_bits(self.eax, 12, 15) as u8;
+        Associativity::for_l2(assoc_bits)
+    }
+
+    /// L2 Instruction TLB number of entries for 2-MB and 4-MB pages.
+    ///
+    /// The value returned is for the number of entries available for the 2-MB page size;
+    /// 4-MB pages require two 2-MB entries, so the number of entries available for the
+    /// 4-MB page size is one-half the returned value.
+    ///
+    /// # Availability
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn itlb_2m_4m_size(&self) -> u16 {
+        get_bits(self.eax, 0, 11) as u16
+    }
+
+    /// L2 Data TLB associativity for 4K pages.
+    ///
+    /// # Availability
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn dtlb_4k_associativity(&self) -> Associativity {
+        let assoc_bits = get_bits(self.ebx, 28, 31) as u8;
+        Associativity::for_l2(assoc_bits)
+    }
+
+    /// L2 Data TLB number of entries for 4K pages.
+    ///
+    /// # Availability
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn dtlb_4k_size(&self) -> u16 {
+        get_bits(self.ebx, 16, 27) as u16
+    }
+
+    /// L2 Instruction TLB associativity for 4K pages.
+    ///
+    /// # Availability
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn itlb_4k_associativity(&self) -> Associativity {
+        let assoc_bits = get_bits(self.ebx, 12, 15) as u8;
+        Associativity::for_l2(assoc_bits)
+    }
+
+    /// L2 Instruction TLB number of entries for 4K pages.
+    ///
+    /// # Availability
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn itlb_4k_size(&self) -> u16 {
+        get_bits(self.ebx, 0, 11) as u16
+    }
+
+    /// L2 Cache Line size in bytes
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
+    pub fn l2cache_line_size(&self) -> u8 {
+        get_bits(self.ecx, 0, 7) as u8
+    }
+
+    /// L2 cache lines per tag.
+    ///
+    /// # Availability
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn l2cache_lines_per_tag(&self) -> u8 {
+        get_bits(self.ecx, 8, 11) as u8
+    }
+
+    /// L2 Associativity field
+    ///
+    /// # Availability
+    /// ✅ AMD ✅ Intel
+    pub fn l2cache_associativity(&self) -> Associativity {
+        let assoc_bits = get_bits(self.ecx, 12, 15) as u8;
+        Associativity::for_l2(assoc_bits)
+    }
+
+    /// Cache size in KB.
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
+    pub fn l2cache_size(&self) -> u16 {
+        get_bits(self.ecx, 16, 31) as u16
+    }
+
+    /// L2 Cache Line size in bytes
+    ///
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn l3cache_line_size(&self) -> u8 {
+        get_bits(self.edx, 0, 7) as u8
+    }
+
+    /// L2 cache lines per tag.
+    ///
+    /// # Availability
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn l3cache_lines_per_tag(&self) -> u8 {
+        get_bits(self.edx, 8, 11) as u8
+    }
+
+    /// L2 Associativity field
+    ///
+    /// # Availability
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn l3cache_associativity(&self) -> Associativity {
+        let assoc_bits = get_bits(self.edx, 12, 15) as u8;
+        Associativity::for_l3(assoc_bits)
+    }
+
+    /// Specifies the L3 cache size range
+    ///
+    /// (L3Size[31:18] * 512KB) <= L3 cache size < ((L3Size[31:18]+1) * 512KB).
+    ///
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved=0)
+    pub fn l3cache_size(&self) -> u16 {
+        get_bits(self.edx, 18, 31) as u16
+    }
+}
+
+#[derive(PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub enum Associativity {
+    Disabled,
+    DirectMapped,
+    NWay(u8),
+    FullyAssociative,
+    Unknown,
+}
+
+impl Associativity {
+    /// Constructor for L1 Cache and TLB Associativity Field Encodings
+    fn for_l1(n: u8) -> Associativity {
+        match n {
+            0x0 => Associativity::Disabled, // Intel only, AMD is reserved
+            0x1 => Associativity::DirectMapped,
+            0x2..=0xfe => Associativity::NWay(n),
+            0xff => Associativity::FullyAssociative,
+        }
+    }
+
+    /// Constructor for L2 Cache and TLB Associativity Field Encodings
+    fn for_l2(n: u8) -> Associativity {
+        match n {
+            0x0 => Associativity::Disabled,
+            0x1 => Associativity::DirectMapped,
+            0x2 => Associativity::NWay(2),
+            0x4 => Associativity::NWay(4),
+            0x5 => Associativity::NWay(6), // Reserved on Intel
+            0x6 => Associativity::NWay(8),
+            0x8 => Associativity::NWay(16),
+            0x9 => Associativity::Unknown, // Intel: Reserved, AMD: Value for all fields should be determined from Fn8000_001D
+            0xa => Associativity::NWay(32),
+            0xb => Associativity::NWay(48),
+            0xc => Associativity::NWay(64),
+            0xd => Associativity::NWay(96),
+            0xe => Associativity::NWay(128),
+            0xF => Associativity::FullyAssociative,
+            _ => Associativity::Unknown,
+        }
+    }
+
+    /// Constructor for L2 Cache and TLB Associativity Field Encodings
+    fn for_l3(n: u8) -> Associativity {
+        Associativity::for_l2(n)
+    }
+}
+
+/// Encrypted Memory Capabilities
+///
+/// # Platforms
+/// ✅ AMD ❌ Intel
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct MemoryEncryptionInfo {
+    eax: MemoryEncryptionInfoEax,
+    ebx: u32,
+    ecx: u32,
+    edx: u32,
+}
+
+impl MemoryEncryptionInfo {
+    pub(crate) fn new(data: CpuIdResult) -> Self {
+        Self {
+            // Safety: We want to preserve not (yet) supported bits from cpuid.
+            eax: unsafe { MemoryEncryptionInfoEax::from_bits_unchecked(data.eax) },
+            ebx: data.ebx,
+            ecx: data.ecx,
+            edx: data.edx,
+        }
+    }
+
+    /// Secure Memory Encryption is supported if set.
+    pub fn has_sme(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::SME)
+    }
+
+    /// Secure Encrypted Virtualization is supported if set.
+    pub fn has_sev(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::SEV)
+    }
+
+    /// The Page Flush MSR is available if set.
+    pub fn has_page_flush_msr(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::PAGE_FLUSH_MSR)
+    }
+
+    /// SEV Encrypted State is supported if set.
+    pub fn has_sev_es(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::SEV_ES)
+    }
+
+    /// SEV Secure Nested Paging supported if set.
+    pub fn has_sev_snp(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::SEV_SNP)
+    }
+
+    /// VM Permission Levels supported if set.
+    pub fn has_vmpl(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::VMPL)
+    }
+
+    /// Hardware cache coherency across encryption domains enforced if set.
+    pub fn has_hw_enforced_cache_coh(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::HWENFCACHECOH)
+    }
+
+    /// SEV guest execution only allowed from a 64-bit host if set.
+    pub fn has_64bit_mode(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::HOST64)
+    }
+
+    /// Restricted Injection supported if set.
+    pub fn has_restricted_injection(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::RESTINJECT)
+    }
+
+    /// Alternate Injection supported if set.
+    pub fn has_alternate_injection(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::ALTINJECT)
+    }
+
+    /// Full debug state swap supported for SEV-ES guests.
+    pub fn has_debug_swap(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::DBGSWP)
+    }
+
+    /// Disallowing IBS use by the host supported if set.
+    pub fn has_prevent_host_ibs(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::PREVHOSTIBS)
+    }
+
+    /// Virtual Transparent Encryption supported if set.
+    pub fn has_vte(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::VTE)
+    }
+
+    /// C-bit location in page table entry
+    pub fn c_bit_position(&self) -> u8 {
+        get_bits(self.ebx, 0, 5) as u8
+    }
+
+    /// Physical Address bit reduction
+    pub fn physical_address_reduction(&self) -> u8 {
+        get_bits(self.ebx, 6, 11) as u8
+    }
+
+    /// Number of encrypted guests supported simultaneouslys
+    pub fn max_encrypted_guests(&self) -> u32 {
+        self.ecx
+    }
+
+    /// Minimum ASID value for an SEV enabled, SEV-ES disabled guest
+    pub fn min_sev_no_es_asid(&self) -> u32 {
+        self.edx
+    }
+}
+
+bitflags! {
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+    struct MemoryEncryptionInfoEax: u32 {
+        const SME = 1 << 0;
+        const SEV = 1 << 1;
+        const PAGE_FLUSH_MSR = 1 << 2;
+        const SEV_ES = 1 << 3;
+        const SEV_SNP = 1 << 4;
+        const VMPL = 1 << 5;
+        const HWENFCACHECOH = 1 << 10;
+        const HOST64 = 1 << 11;
+        const RESTINJECT = 1 << 12;
+        const ALTINJECT = 1 << 13;
+        const DBGSWP = 1 << 14;
+        const PREVHOSTIBS = 1 << 15;
+        const VTE = 1 << 16;
     }
 }

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -591,7 +591,7 @@ impl L1CacheTlbInfo {
     }
 }
 
-/// L2 Cache and TLB Information (LEAF=0x8000_0006).
+/// L2/L3 Cache and TLB Information (LEAF=0x8000_0006).
 ///
 /// # Availability
 /// ✅ AMD 🟡 Intel
@@ -605,6 +605,15 @@ pub struct L2And3CacheTlbInfo {
 }
 
 impl L2And3CacheTlbInfo {
+    pub(crate) fn new(data: CpuIdResult) -> Self {
+        Self {
+            eax: data.eax,
+            ebx: data.ebx,
+            ecx: data.ecx,
+            edx: data.edx,
+        }
+    }
+
     /// L2 Data TLB associativity for 2-MB and 4-MB pages.
     ///
     /// # Availability

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -113,6 +113,10 @@ impl ExtendedProcessorFeatureIdentifiers {
 
     /// Is LZCNT available?
     ///
+    /// # AMD
+    /// It's called ABM (Advanced bit manipulation) on AMD and also adds support for
+    /// some other instructions.
+    ///
     /// # Platforms
     /// ✅ AMD ✅ Intel
     pub fn has_lzcnt(&self) -> bool {

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -4,10 +4,187 @@ use core::mem::size_of;
 use core::slice;
 use core::str;
 
-use crate::CpuIdResult;
+use crate::{get_bits, CpuIdResult, Vendor};
+
+/// Extended Processor and Processor Feature Identifiers (LEAF=0x8000_0001)
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct ExtendedProcessorFeatureIdentifiers {
+    vendor: Vendor,
+    eax: u32,
+    ebx: u32,
+    ecx: ExtendedFunctionInfoEcx,
+    edx: ExtendedFunctionInfoEdx,
+}
+
+impl ExtendedProcessorFeatureIdentifiers {
+    pub(crate) fn new(vendor: Vendor, data: CpuIdResult) -> Self {
+        Self {
+            vendor,
+            eax: data.eax,
+            ebx: data.ebx,
+            // Safety: Ok we don't care/want to preseve extra bits from CpuId that we don't support (yet)
+            ecx: unsafe { ExtendedFunctionInfoEcx::from_bits_unchecked(data.ecx) },
+            // Safety: Ok we don't care/want to preseve extra bits from CpuId that we don't support (yet)
+            edx: unsafe { ExtendedFunctionInfoEdx::from_bits_unchecked(data.edx) },
+        }
+    }
+
+    /// Extended Processor Signature.
+    ///
+    /// # AMD
+    /// The value returned is the same as the value returned in EAX for LEAF=0x0000_0001
+    /// (use `CpuId.get_feature_info` instead)
+    ///
+    /// # Intel
+    /// Vague mention of "Extended Processor Signature", not clear what it's supposed to represent.
+    pub fn extended_signature(&self) -> u32 {
+        self.eax
+    }
+
+    /// Returns package type on AMD.
+    ///
+    /// # Intel
+    /// This field is not used (reseved).
+    ///
+    /// # AMD
+    /// Package type. If (Family[7:0] >= 10h), this field is valid.
+    /// If (Family[7:0]<10h), this field is reserved
+    pub fn pkg_type(&self) -> u32 {
+        get_bits(self.ebx, 28, 31)
+    }
+
+    /// Returns brand ID on AMD.
+    ///
+    /// # Intel
+    /// This field is not used (reserved).
+    ///
+    /// # AMD
+    /// This field, in conjunction with CPUID
+    /// LEAF=0x0000_0001_EBX[8BitBrandId], and used by firmware to generate the
+    /// processor name string.
+    pub fn brand_id(&self) -> u32 {
+        get_bits(self.ebx, 0, 15)
+    }
+
+    /// Is LAHF/SAHF available in 64-bit mode?
+    pub fn has_lahf_sahf(&self) -> bool {
+        self.ecx.contains(ExtendedFunctionInfoEcx::LAHF_SAHF)
+    }
+
+    /// Check support for 64-bit mode.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_cmp_legacy(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::CMP_LEGACY)
+    }
+
+    /// Secure virtual machine supported.
+    ///
+    /// # Intel
+    /// This feature unavailable on Intel (will return false).
+    pub fn has_svm(&self) -> bool {
+        self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SVM)
+    }
+
+    /// Is LZCNT available?
+    pub fn has_lzcnt(&self) -> bool {
+        self.ecx.contains(ExtendedFunctionInfoEcx::LZCNT)
+    }
+
+    /// Is PREFETCHW available?
+    pub fn has_prefetchw(&self) -> bool {
+        self.ecx.contains(ExtendedFunctionInfoEcx::PREFETCHW)
+    }
+
+    /// Are fast system calls available.
+    pub fn has_syscall_sysret(&self) -> bool {
+        self.edx.contains(ExtendedFunctionInfoEdx::SYSCALL_SYSRET)
+    }
+
+    /// Is there support for execute disable bit.
+    pub fn has_execute_disable(&self) -> bool {
+        self.edx.contains(ExtendedFunctionInfoEdx::EXECUTE_DISABLE)
+    }
+
+    /// Is there support for 1GiB pages.
+    pub fn has_1gib_pages(&self) -> bool {
+        self.edx.contains(ExtendedFunctionInfoEdx::GIB_PAGES)
+    }
+
+    /// Check support for rdtscp instruction.
+    pub fn has_rdtscp(&self) -> bool {
+        self.edx.contains(ExtendedFunctionInfoEdx::RDTSCP)
+    }
+
+    /// Check support for 64-bit mode.
+    pub fn has_64bit_mode(&self) -> bool {
+        self.edx.contains(ExtendedFunctionInfoEdx::I64BIT_MODE)
+    }
+}
+
+impl Debug for ExtendedProcessorFeatureIdentifiers {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("ExtendedProcessorFeatureIdentifiers");
+        ds.field("extended_signature", &self.extended_signature());
+
+        if self.vendor == Vendor::Amd {
+            ds.field("pkg_type", &self.pkg_type());
+            ds.field("brand_id", &self.brand_id());
+        }
+        ds.field("ecx_features", &self.ecx);
+        ds.field("edx_features", &self.edx);
+        ds.finish()
+    }
+}
+
+bitflags! {
+    #[derive(Default)]
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+    struct ExtendedFunctionInfoEcx: u32 {
+        const LAHF_SAHF = 1 << 0;
+        const CMP_LEGACY =  1 << 1;
+        const SVM = 1 << 2;
+        const EXT_APIC_SPACE = 1 << 3;
+        const ALTMOVCR8 = 1 << 4;
+        const LZCNT = 1 << 5;
+        const SSE4A = 1 << 6;
+        const MISALIGNSSE = 1 << 7;
+        const PREFETCHW = 1 << 8;
+        const OSVW = 1 << 9;
+        const IBS = 1 << 10;
+        const XOP = 1 << 11;
+        const SKINIT = 1 << 12;
+        const WDT = 1 << 13;
+        const LWP = 1 << 15;
+        const FMA4 = 1 << 16;
+        const TBM = 1 << 21;
+        const TOPEXT = 1 << 22;
+        const PERFCTREXT = 1 << 23;
+        const PERFCTREXTNB = 1 << 24;
+        const DATABRKPEXT = 1 << 26;
+        const PERFTSC = 1 << 27;
+        const PERFCTREXTLLC = 1 << 28;
+        const MONITORX = 1 << 29;
+        const ADDRMASKEXT = 1 << 30;
+    }
+}
+
+bitflags! {
+    #[derive(Default)]
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+    struct ExtendedFunctionInfoEdx: u32 {
+        const SYSCALL_SYSRET = 1 << 11;
+        const EXECUTE_DISABLE = 1 << 20;
+        const GIB_PAGES = 1 << 26;
+        const RDTSCP = 1 << 27;
+        const I64BIT_MODE = 1 << 29;
+    }
+}
 
 /// ASCII string up to 48 characters in length corresponding to the processor name.
 /// (LEAF = 0x8000_0002..=0x8000_0004)
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ProcessorBrandString {
     data: [CpuIdResult; 3],
 }
@@ -23,7 +200,7 @@ impl ProcessorBrandString {
     /// "11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz".
     pub fn as_str(&self) -> &str {
         // Safety: CpuIdResult is laid out with repr(C), and the array
-        // self.data contains 3 continguous elements.
+        // self.data contains 3 contiguous elements.
         let slice: &[u8] = unsafe {
             slice::from_raw_parts(
                 self.data.as_ptr() as *const u8,

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -436,3 +436,17 @@ impl Debug for ProcessorBrandString {
             .finish()
     }
 }
+
+/// L1 Cache and TLB Information.
+///
+/// # Intel
+/// This info is unavailable on Intel CPUs.
+pub struct L1CacheTlbInfo {
+    data: CpuIdResult,
+}
+
+impl L1CacheTlbInfo {
+    pub(crate) fn new(data: CpuIdResult) -> Self {
+        Self { data }
+    }
+}

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -74,7 +74,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Check support for 64-bit mode.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_cmp_legacy(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::CMP_LEGACY)
     }
@@ -82,7 +82,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Secure virtual machine supported.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_svm(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SVM)
     }
@@ -90,7 +90,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Extended APIC space. This bit indicates the presence of extended APIC register space starting at offset 400h from the “APIC Base Address Register,” as specified in the BKDG.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_ext_apic_space(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::EXT_APIC_SPACE)
     }
@@ -98,7 +98,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// LOCK MOV CR0 means MOV CR8. See “MOV(CRn)” in APM3.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_alt_mov_cr8(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::ALTMOVCR8)
     }
@@ -112,7 +112,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// See “EXTRQ”, “INSERTQ”, “MOVNTSS”, and “MOVNTSD” in APM4.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_sse4a(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SSE4A)
     }
@@ -120,7 +120,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Misaligned SSE mode. See “Misaligned Access Support Added for SSE Instructions” in APM1.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_misaligned_sse_mode(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::MISALIGNSSE)
     }
@@ -136,7 +136,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Indicates OS-visible workaround support
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_osvw(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::OSVW)
     }
@@ -144,7 +144,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Instruction based sampling.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_ibs(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::IBS)
     }
@@ -152,7 +152,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Extended operation support.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_xop(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::XOP)
     }
@@ -163,7 +163,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// the value of MSRC000_0080[SVME].
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_skinit(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SKINIT)
     }
@@ -173,7 +173,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Indicates support for MSRC001_0074.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_wdt(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::WDT)
     }
@@ -181,7 +181,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Lightweight profiling support
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_lwp(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::LWP)
     }
@@ -189,15 +189,15 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Four-operand FMA instruction support.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_fma4(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::FMA4)
     }
 
-    /// Trailing bit manipulation instruction support. .
+    /// Trailing bit manipulation instruction support.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_tbm(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::TBM)
     }
@@ -207,7 +207,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Indicates support for CPUID Fn8000_001D_EAX_x[N:0]-CPUID Fn8000_001E_EDX.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_topology_extensions(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::TOPEXT)
     }
@@ -217,7 +217,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Indicates support for MSRC001_020[A,8,6,4,2,0] and MSRC001_020[B,9,7,5,3,1].
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_perf_cntr_extensions(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFCTREXT)
     }
@@ -227,7 +227,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Indicates support for MSRC001_024[6,4,2,0] and MSRC001_024[7,5,3,1].
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_nb_perf_cntr_extensions(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFCTREXTNB)
     }
@@ -237,7 +237,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Indicates support for MSRC001_1027 and MSRC001_101[B:9].
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_data_access_bkpt_extension(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::DATABRKPEXT)
     }
@@ -247,7 +247,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Indicates support for MSRC001_0280 [Performance Time Stamp Counter].
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_perf_tsc(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFTSC)
     }
@@ -255,7 +255,7 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Support for L3 performance counter extension.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_perf_cntr_llc_extensions(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFCTREXTLLC)
     }
@@ -263,15 +263,15 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Support for MWAITX and MONITORX instructions.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_monitorx_mwaitx(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::MONITORX)
     }
 
-    /// Breakpoint Addressing masking extended to bit 31. .
+    /// Breakpoint Addressing masking extended to bit 31.
     ///
     /// # Intel
-    /// This feature unavailable on Intel (will return false).
+    /// This feature is unavailable on Intel CPUs (will return false).
     pub fn has_addr_mask_extension(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::ADDRMASKEXT)
     }
@@ -284,6 +284,22 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Is there support for execute disable bit.
     pub fn has_execute_disable(&self) -> bool {
         self.edx.contains(ExtendedFunctionInfoEdx::EXECUTE_DISABLE)
+    }
+
+    /// AMD extensions to MMX instructions.
+    ///
+    /// # Intel
+    /// This feature is unavailable on Intel CPUs (will return false).
+    pub fn has_mmx_extensions(&self) -> bool {
+        self.vendor == Vendor::Amd && self.edx.contains(ExtendedFunctionInfoEdx::MMXEXT)
+    }
+
+    /// FXSAVE and FXRSTOR instruction optimizations.
+    ///
+    /// # Intel
+    /// This feature is unavailable on Intel CPUs (will return false).
+    pub fn has_fast_fxsave_fxstor(&self) -> bool {
+        self.vendor == Vendor::Amd && self.edx.contains(ExtendedFunctionInfoEdx::FFXSR)
     }
 
     /// Is there support for 1GiB pages.
@@ -299,6 +315,22 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// Check support for 64-bit mode.
     pub fn has_64bit_mode(&self) -> bool {
         self.edx.contains(ExtendedFunctionInfoEdx::I64BIT_MODE)
+    }
+
+    /// 3DNow AMD extensions.
+    ///
+    /// # Intel
+    /// This feature is unavailable on Intel CPUs (will return false).
+    pub fn has_amd_3dnow_extensions(&self) -> bool {
+        self.vendor == Vendor::Amd && self.edx.contains(ExtendedFunctionInfoEdx::THREEDNOWEXT)
+    }
+
+    /// 3DNow extensions.
+    ///
+    /// # Intel
+    /// This feature is unavailable on Intel CPUs (will return false).
+    pub fn has_3dnow(&self) -> bool {
+        self.vendor == Vendor::Amd && self.edx.contains(ExtendedFunctionInfoEdx::THREEDNOW)
     }
 }
 
@@ -355,9 +387,13 @@ bitflags! {
     struct ExtendedFunctionInfoEdx: u32 {
         const SYSCALL_SYSRET = 1 << 11;
         const EXECUTE_DISABLE = 1 << 20;
+        const MMXEXT = 1 << 22;
+        const FFXSR = 1 << 24;
         const GIB_PAGES = 1 << 26;
         const RDTSCP = 1 << 27;
         const I64BIT_MODE = 1 << 29;
+        const THREEDNOWEXT = 1 << 30;
+        const THREEDNOW = 1 << 31;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,6 @@ pub mod native_cpuid {
     }
 }
 
-use core::cmp::min;
 use core::fmt;
 use core::fmt::{Debug, Formatter};
 use core::mem::size_of;
@@ -295,6 +294,8 @@ const EAX_EXTENDED_PROCESSOR_AND_FEATURE_IDENTIFIERS: u32 = 0x8000_0001;
 const EAX_EXTENDED_BRAND_STRING: u32 = 0x8000_0002;
 const EAX_L1_CACHE_INFO: u32 = 0x8000_0005;
 const EAX_L2_L3_CACHE_INFO: u32 = 0x8000_0006;
+const EAX_ADVANCED_POWER_MGMT_INFO: u32 = 0x8000_0007;
+const EAX_PROCESSOR_CAPACITY_INFO: u32 = 0x8000_0008;
 const EAX_MEMORY_ENCRYPTION_INFO: u32 = 0x8000_001F;
 
 impl CpuId {
@@ -766,7 +767,7 @@ impl CpuId {
     /// # Platforms
     /// ✅ AMD ❌ Intel (reserved)
     pub fn get_l1_cache_and_tlb_info(&self) -> Option<L1CacheTlbInfo> {
-        if self.vendor == Vendor::Amd && self.leaf_is_supported(EAX_L1_CACHE_INFO) {
+        if self.leaf_is_supported(EAX_L1_CACHE_INFO) {
             Some(L1CacheTlbInfo::new(self.read.cpuid1(EAX_L1_CACHE_INFO)))
         } else {
             None
@@ -778,9 +779,35 @@ impl CpuId {
     /// # Availability
     /// ✅ AMD 🟡 Intel
     pub fn get_l2_l3_cache_and_tlb_info(&self) -> Option<L2And3CacheTlbInfo> {
-        if self.vendor == Vendor::Amd && self.leaf_is_supported(EAX_L2_L3_CACHE_INFO) {
+        if self.leaf_is_supported(EAX_L2_L3_CACHE_INFO) {
             Some(L2And3CacheTlbInfo::new(
                 self.read.cpuid1(EAX_L2_L3_CACHE_INFO),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Advanced Power Management Information (LEAF=0x8000_0007).
+    ///
+    /// # Availability
+    /// ✅ AMD 🟡 Intel
+    pub fn get_advanced_power_mgmt_info(&self) -> Option<ApmInfo> {
+        if self.leaf_is_supported(EAX_ADVANCED_POWER_MGMT_INFO) {
+            Some(ApmInfo::new(self.read.cpuid1(EAX_ADVANCED_POWER_MGMT_INFO)))
+        } else {
+            None
+        }
+    }
+
+    /// Processor Capacity Parameters and Extended Feature Identification (LEAF=0x8000_0008).
+    ///
+    /// # Availability
+    /// ✅ AMD 🟡 Intel
+    pub fn get_processor_capacity_feature_info(&self) -> Option<ProcessorCapacityAndFeatureInfo> {
+        if self.leaf_is_supported(EAX_PROCESSOR_CAPACITY_INFO) {
+            Some(ProcessorCapacityAndFeatureInfo::new(
+                self.read.cpuid1(EAX_PROCESSOR_CAPACITY_INFO),
             ))
         } else {
             None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4951,78 +4951,6 @@ impl ExtendedFunctionInfo {
     pub fn has_invariant_tsc(&self) -> bool {
         self.leaf_is_supported(7) && self.data[7].edx & (1 << 8) > 0
     }
-
-    /// Is LAHF/SAHF available in 64-bit mode?
-    pub fn has_lahf_sahf(&self) -> bool {
-        self.leaf_is_supported(1)
-            && ExtendedFunctionInfoEcx {
-                bits: self.data[1].ecx,
-            }
-            .contains(ExtendedFunctionInfoEcx::LAHF_SAHF)
-    }
-
-    /// Is LZCNT available?
-    pub fn has_lzcnt(&self) -> bool {
-        self.leaf_is_supported(1)
-            && ExtendedFunctionInfoEcx {
-                bits: self.data[1].ecx,
-            }
-            .contains(ExtendedFunctionInfoEcx::LZCNT)
-    }
-
-    /// Is PREFETCHW available?
-    pub fn has_prefetchw(&self) -> bool {
-        self.leaf_is_supported(1)
-            && ExtendedFunctionInfoEcx {
-                bits: self.data[1].ecx,
-            }
-            .contains(ExtendedFunctionInfoEcx::PREFETCHW)
-    }
-
-    /// Are fast system calls available.
-    pub fn has_syscall_sysret(&self) -> bool {
-        self.leaf_is_supported(1)
-            && ExtendedFunctionInfoEdx {
-                bits: self.data[1].edx,
-            }
-            .contains(ExtendedFunctionInfoEdx::SYSCALL_SYSRET)
-    }
-
-    /// Is there support for execute disable bit.
-    pub fn has_execute_disable(&self) -> bool {
-        self.leaf_is_supported(1)
-            && ExtendedFunctionInfoEdx {
-                bits: self.data[1].edx,
-            }
-            .contains(ExtendedFunctionInfoEdx::EXECUTE_DISABLE)
-    }
-
-    /// Is there support for 1GiB pages.
-    pub fn has_1gib_pages(&self) -> bool {
-        self.leaf_is_supported(1)
-            && ExtendedFunctionInfoEdx {
-                bits: self.data[1].edx,
-            }
-            .contains(ExtendedFunctionInfoEdx::GIB_PAGES)
-    }
-
-    /// Check support for rdtscp instruction.
-    pub fn has_rdtscp(&self) -> bool {
-        self.leaf_is_supported(1)
-            && ExtendedFunctionInfoEdx {
-                bits: self.data[1].edx,
-            }
-            .contains(ExtendedFunctionInfoEdx::RDTSCP)
-    }
-
-    /// Check support for 64-bit mode.
-    pub fn has_64bit_mode(&self) -> bool {
-        self.leaf_is_supported(1)
-            && ExtendedFunctionInfoEdx {
-                bits: self.data[1].edx,
-            }
-            .contains(ExtendedFunctionInfoEdx::I64BIT_MODE)
-    }
 }
 
 /*impl Debug for ExtendedFunctionInfo {
@@ -5047,36 +4975,6 @@ impl ExtendedFunctionInfo {
             .finish()
     }
 }*/
-
-bitflags! {
-    #[derive(Default)]
-    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-    struct ExtendedFunctionInfoEcx: u32 {
-        /// LAHF/SAHF available in 64-bit mode.
-        const LAHF_SAHF = 1 << 0;
-        /// Bit 05: LZCNT
-        const LZCNT = 1 << 5;
-        /// Bit 08: PREFETCHW
-        const PREFETCHW = 1 << 8;
-    }
-}
-
-bitflags! {
-    #[derive(Default)]
-    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-    struct ExtendedFunctionInfoEdx: u32 {
-        /// SYSCALL/SYSRET available in 64-bit mode (Bit 11).
-        const SYSCALL_SYSRET = 1 << 11;
-        /// Execute Disable Bit available (Bit 20).
-        const EXECUTE_DISABLE = 1 << 20;
-        /// 1-GByte pages are available if 1 (Bit 26).
-        const GIB_PAGES = 1 << 26;
-        /// RDTSCP and IA32_TSC_AUX are available if 1 (Bit 27).
-        const RDTSCP = 1 << 27;
-        /// Intel ® 64 Architecture available if 1 (Bit 29).
-        const I64BIT_MODE = 1 << 29;
-    }
-}
 
 #[derive(Debug, Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -832,8 +832,11 @@ impl Debug for CpuId {
             )
             .field("soc_vendor_info", &self.get_soc_vendor_info())
             .field("hypervisor_info", &self.get_hypervisor_info())
+            .field(
+                "extended_processor_and_feature_identifiers",
+                &self.get_extended_processor_and_feature_identifiers(),
+            )
             .field("processor_brand_string", &self.get_processor_brand_string())
-            //.field("extended_function_info", &self.get_extended_function_info())
             .field("memory_encryption_info", &self.get_memory_encryption_info())
             .finish()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,7 @@ const EAX_HYPERVISOR_INFO: u32 = 0x4000_0000;
 const EAX_EXTENDED_FUNCTION_INFO: u32 = 0x8000_0000;
 const EAX_EXTENDED_PROCESSOR_AND_FEATURE_IDENTIFIERS: u32 = 0x8000_0001;
 const EAX_EXTENDED_BRAND_STRING: u32 = 0x8000_0002;
+const EAX_L1_CACHE_INFO: u32 = 0x8000_0005;
 const EAX_MEMORY_ENCRYPTION_INFO: u32 = 0x8000_001F;
 
 impl CpuId {
@@ -668,7 +669,7 @@ impl CpuId {
     }
 
     /// Retrieve processor brand string leafs.
-    pub fn get_processor_brand_string<'a>(&'a self) -> Option<ProcessorBrandString> {
+    pub fn get_processor_brand_string(&self) -> Option<ProcessorBrandString> {
         if self.leaf_is_supported(EAX_EXTENDED_BRAND_STRING)
             && self.leaf_is_supported(EAX_EXTENDED_BRAND_STRING + 1)
             && self.leaf_is_supported(EAX_EXTENDED_BRAND_STRING + 2)
@@ -678,6 +679,18 @@ impl CpuId {
                 self.read.cpuid1(EAX_EXTENDED_BRAND_STRING + 1),
                 self.read.cpuid1(EAX_EXTENDED_BRAND_STRING + 2),
             ]))
+        } else {
+            None
+        }
+    }
+
+    /// L1 Instruction Cache Information (LEAF=0x8000_0005)
+    ///
+    /// # Intel
+    /// This leaf is not supported on Intel (will return None).
+    pub fn get_l1_cache_and_tlb_info(&self) -> Option<L1CacheTlbInfo> {
+        if self.vendor == Vendor::Amd && self.leaf_is_supported(EAX_L1_CACHE_INFO) {
+            Some(L1CacheTlbInfo::new(self.read.cpuid1(EAX_L1_CACHE_INFO)))
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,6 +278,7 @@ const EAX_HYPERVISOR_INFO: u32 = 0x4000_0000;
 //
 
 const EAX_EXTENDED_FUNCTION_INFO: u32 = 0x8000_0000;
+const EAX_EXTENDED_PROCESSOR_AND_FEATURE_IDENTIFIERS: u32 = 0x8000_0001;
 const EAX_EXTENDED_BRAND_STRING: u32 = 0x8000_0002;
 const EAX_MEMORY_ENCRYPTION_INFO: u32 = 0x8000_001F;
 
@@ -648,6 +649,22 @@ impl CpuId {
                 }
             })
             .flatten()
+    }
+
+    /// Extended Processor and Processor Feature Identifiers.
+    /// (LEAF=0x8000_0001)
+    pub fn get_extended_processor_and_feature_identifiers(
+        &self,
+    ) -> Option<ExtendedProcessorFeatureIdentifiers> {
+        if self.leaf_is_supported(EAX_EXTENDED_PROCESSOR_AND_FEATURE_IDENTIFIERS) {
+            Some(ExtendedProcessorFeatureIdentifiers::new(
+                self.vendor,
+                self.read
+                    .cpuid1(EAX_EXTENDED_PROCESSOR_AND_FEATURE_IDENTIFIERS),
+            ))
+        } else {
+            None
+        }
     }
 
     /// Retrieve processor brand string leafs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,10 @@
 //!   for more information.
 //! - ❌: This struct/function is not supported by the vendor. When queried on this
 //!   platform, we will return None/false/0 (or some other sane default).
+//!
+//! Note that the presence of a ✅ does not guarantee that a specific feature will exist
+//! for your CPU -- just that it is potentially supported by the vendor on some of its
+//! chips. You will still have to query it at runtime.
 
 #![no_std]
 #![crate_name = "raw_cpuid"]
@@ -290,6 +294,7 @@ const EAX_EXTENDED_FUNCTION_INFO: u32 = 0x8000_0000;
 const EAX_EXTENDED_PROCESSOR_AND_FEATURE_IDENTIFIERS: u32 = 0x8000_0001;
 const EAX_EXTENDED_BRAND_STRING: u32 = 0x8000_0002;
 const EAX_L1_CACHE_INFO: u32 = 0x8000_0005;
+const EAX_L2_L3_CACHE_INFO: u32 = 0x8000_0006;
 const EAX_MEMORY_ENCRYPTION_INFO: u32 = 0x8000_001F;
 
 impl CpuId {
@@ -328,6 +333,9 @@ impl CpuId {
     /// Return information about vendor.
     /// This is typically a ASCII readable string such as
     /// GenuineIntel for Intel CPUs or AuthenticAMD for AMD CPUs (LEAF=0x00).
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn get_vendor_info(&self) -> Option<VendorInfo> {
         if self.leaf_is_supported(EAX_VENDOR_INFO) {
             let res = self.read.cpuid1(EAX_VENDOR_INFO);
@@ -342,6 +350,9 @@ impl CpuId {
     }
 
     /// Query a set of features that are available on this CPU (LEAF=0x01).
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn get_feature_info(&self) -> Option<FeatureInfo> {
         if self.leaf_is_supported(EAX_FEATURE_INFO) {
             let res = self.read.cpuid1(EAX_FEATURE_INFO);
@@ -360,6 +371,9 @@ impl CpuId {
 
     /// Query basic information about caches. This will just return an index
     /// into a static table of cache descriptions (see `CACHE_INFO_TABLE`) (LEAF=0x02).
+    ///
+    /// # Platforms
+    /// ❌ AMD ✅ Intel
     pub fn get_cache_info(&self) -> Option<CacheInfoIter> {
         if self.leaf_is_supported(EAX_CACHE_INFO) {
             let res = self.read.cpuid1(EAX_CACHE_INFO);
@@ -376,6 +390,9 @@ impl CpuId {
     }
 
     /// Retrieve serial number of processor (LEAF=0x03).
+    ///
+    /// # Platforms
+    /// ❌ AMD ✅ Intel
     pub fn get_processor_serial(&self) -> Option<ProcessorSerial> {
         if self.leaf_is_supported(EAX_PROCESSOR_SERIAL) {
             let res = self.read.cpuid1(EAX_PROCESSOR_SERIAL);
@@ -391,6 +408,9 @@ impl CpuId {
     /// Retrieve more elaborate information about caches (as opposed
     /// to `get_cache_info`). This will tell us about associativity,
     /// set size, line size etc. for each level of the cache hierarchy (LEAF=0x04).
+    ///
+    /// # Platforms
+    /// ❌ AMD ✅ Intel
     pub fn get_cache_parameters(&self) -> Option<CacheParametersIter> {
         if self.leaf_is_supported(EAX_CACHE_PARAMETERS) {
             Some(CacheParametersIter {
@@ -403,6 +423,9 @@ impl CpuId {
     }
 
     /// Information about how monitor/mwait works on this CPU (LEAF=0x05).
+    ///
+    /// # Platforms
+    /// 🟡 AMD ✅ Intel
     pub fn get_monitor_mwait_info(&self) -> Option<MonitorMwaitInfo> {
         if self.leaf_is_supported(EAX_MONITOR_MWAIT_INFO) {
             let res = self.read.cpuid1(EAX_MONITOR_MWAIT_INFO);
@@ -418,6 +441,9 @@ impl CpuId {
     }
 
     /// Query information about thermal and power management features of the CPU (LEAF=0x06).
+    ///
+    /// # Platforms
+    /// 🟡 AMD ✅ Intel
     pub fn get_thermal_power_info(&self) -> Option<ThermalPowerInfo> {
         if self.leaf_is_supported(EAX_THERMAL_POWER_INFO) {
             let res = self.read.cpuid1(EAX_THERMAL_POWER_INFO);
@@ -433,6 +459,9 @@ impl CpuId {
     }
 
     /// Find out about more features supported by this CPU (LEAF=0x07).
+    ///
+    /// # Platforms
+    /// 🟡 AMD ✅ Intel
     pub fn get_extended_feature_info(&self) -> Option<ExtendedFeatures> {
         if self.leaf_is_supported(EAX_STRUCTURED_EXTENDED_FEATURE_INFO) {
             let res = self.read.cpuid1(EAX_STRUCTURED_EXTENDED_FEATURE_INFO);
@@ -448,6 +477,9 @@ impl CpuId {
     }
 
     /// Direct cache access info (LEAF=0x09).
+    ///
+    /// # Platforms
+    /// ❌ AMD ✅ Intel
     pub fn get_direct_cache_access_info(&self) -> Option<DirectCacheAccessInfo> {
         if self.leaf_is_supported(EAX_DIRECT_CACHE_ACCESS_INFO) {
             let res = self.read.cpuid1(EAX_DIRECT_CACHE_ACCESS_INFO);
@@ -458,6 +490,9 @@ impl CpuId {
     }
 
     /// Info about performance monitoring -- how many counters etc (LEAF=0x0A)
+    ///
+    /// # Platforms
+    /// ❌ AMD ✅ Intel
     pub fn get_performance_monitoring_info(&self) -> Option<PerformanceMonitoringInfo> {
         if self.leaf_is_supported(EAX_PERFORMANCE_MONITOR_INFO) {
             let res = self.read.cpuid1(EAX_PERFORMANCE_MONITOR_INFO);
@@ -473,6 +508,9 @@ impl CpuId {
     }
 
     /// Information about topology -- how many cores and what kind of cores (LEAF=0x0B).
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn get_extended_topology_info(&self) -> Option<ExtendedTopologyIter> {
         if self.leaf_is_supported(EAX_EXTENDED_TOPOLOGY_INFO) {
             Some(ExtendedTopologyIter {
@@ -485,6 +523,9 @@ impl CpuId {
     }
 
     /// Information for saving/restoring extended register state (LEAF=0x0D).
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn get_extended_state_info(&self) -> Option<ExtendedStateInfo> {
         if self.leaf_is_supported(EAX_EXTENDED_STATE_INFO) {
             let res = self.read.cpuid2(EAX_EXTENDED_STATE_INFO, 0);
@@ -535,6 +576,9 @@ impl CpuId {
     }
 
     /// Information about secure enclave support (LEAF=0x12).
+    ///
+    /// # Platforms
+    /// ❌ AMD ✅ Intel
     pub fn get_sgx_info(&self) -> Option<SgxInfo> {
         // Leaf 12H sub-leaf 0 (ECX = 0) is supported if CPUID.(EAX=07H, ECX=0H):EBX[SGX] = 1.
         self.get_extended_feature_info().and_then(|info| {
@@ -559,6 +603,9 @@ impl CpuId {
     }
 
     /// Intel Processor Trace Enumeration Information (LEAF=0x14).
+    ///
+    /// # Platforms
+    /// ❌ AMD ✅ Intel
     pub fn get_processor_trace_info(&self) -> Option<ProcessorTraceInfo> {
         if self.leaf_is_supported(EAX_TRACE_INFO) {
             let res = self.read.cpuid2(EAX_TRACE_INFO, 0);
@@ -581,6 +628,9 @@ impl CpuId {
     }
 
     /// Time Stamp Counter/Core Crystal Clock Information (LEAF=0x15).
+    ///
+    /// # Platforms
+    /// ❌ AMD ✅ Intel
     pub fn get_tsc_info(&self) -> Option<TscInfo> {
         if self.leaf_is_supported(EAX_TIME_STAMP_COUNTER_INFO) {
             let res = self.read.cpuid2(EAX_TIME_STAMP_COUNTER_INFO, 0);
@@ -595,6 +645,9 @@ impl CpuId {
     }
 
     /// Processor Frequency Information (LEAF=0x16).
+    ///
+    /// # Platforms
+    /// ❌ AMD ✅ Intel
     pub fn get_processor_frequency_info(&self) -> Option<ProcessorFrequencyInfo> {
         if self.leaf_is_supported(EAX_FREQUENCY_INFO) {
             let res = self.read.cpuid1(EAX_FREQUENCY_INFO);
@@ -609,6 +662,9 @@ impl CpuId {
     }
 
     /// Contains SoC vendor specific information (LEAF=0x17).
+    ///
+    /// # Platforms
+    /// ❌ AMD ✅ Intel
     pub fn get_soc_vendor_info(&self) -> Option<SoCVendorInfo> {
         if self.leaf_is_supported(EAX_SOC_VENDOR_INFO) {
             let res = self.read.cpuid1(EAX_SOC_VENDOR_INFO);
@@ -625,6 +681,9 @@ impl CpuId {
     }
 
     /// Contains information about the deterministic address translation feature (LEAF=0x18)
+    ///
+    /// # Platforms
+    /// ❌ AMD ✅ Intel
     pub fn get_deterministic_address_translation_info(&self) -> Option<DatIter> {
         if self.leaf_is_supported(EAX_DETERMINISTIC_ADDRESS_TRANSLATION_INFO) {
             let res = self
@@ -642,6 +701,9 @@ impl CpuId {
 
     /// Returns information provided by the hypervisor, if running
     /// in a virtual environment (LEAF=0x4000_00xx).
+    ///
+    /// # Platform
+    /// Needs to be a virtual CPU to be supported.
     pub fn get_hypervisor_info(&self) -> Option<HypervisorInfo> {
         // We only fetch HypervisorInfo, if the Hypervisor-Flag is set.
         // See https://github.com/gz/rust-cpuid/issues/52
@@ -663,6 +725,9 @@ impl CpuId {
 
     /// Extended Processor and Processor Feature Identifiers.
     /// (LEAF=0x8000_0001)
+    ///
+    /// # Platforms
+    /// ✅ AMD 🟡 Intel
     pub fn get_extended_processor_and_feature_identifiers(
         &self,
     ) -> Option<ExtendedProcessorFeatureIdentifiers> {
@@ -678,6 +743,9 @@ impl CpuId {
     }
 
     /// Retrieve processor brand string leafs.
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
     pub fn get_processor_brand_string(&self) -> Option<ProcessorBrandString> {
         if self.leaf_is_supported(EAX_EXTENDED_BRAND_STRING)
             && self.leaf_is_supported(EAX_EXTENDED_BRAND_STRING + 1)
@@ -695,8 +763,8 @@ impl CpuId {
 
     /// L1 Instruction Cache Information (LEAF=0x8000_0005)
     ///
-    /// # Intel
-    /// This leaf is not supported on Intel (will return None).
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved)
     pub fn get_l1_cache_and_tlb_info(&self) -> Option<L1CacheTlbInfo> {
         if self.vendor == Vendor::Amd && self.leaf_is_supported(EAX_L1_CACHE_INFO) {
             Some(L1CacheTlbInfo::new(self.read.cpuid1(EAX_L1_CACHE_INFO)))
@@ -705,7 +773,24 @@ impl CpuId {
         }
     }
 
+    /// L2/L3 Cache and TLB Information (LEAF=0x8000_0006).
+    ///
+    /// # Availability
+    /// ✅ AMD 🟡 Intel
+    pub fn get_l2_l3_cache_and_tlb_info(&self) -> Option<L2And3CacheTlbInfo> {
+        if self.vendor == Vendor::Amd && self.leaf_is_supported(EAX_L2_L3_CACHE_INFO) {
+            Some(L2And3CacheTlbInfo::new(
+                self.read.cpuid1(EAX_L2_L3_CACHE_INFO),
+            ))
+        } else {
+            None
+        }
+    }
+
     /// Informations about memory encryption support (LEAF=0x8000_001F)
+    ///
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved)
     pub fn get_memory_encryption_info(&self) -> Option<MemoryEncryptionInfo> {
         if self.leaf_is_supported(EAX_MEMORY_ENCRYPTION_INFO) {
             Some(MemoryEncryptionInfo::new(
@@ -714,95 +799,6 @@ impl CpuId {
         } else {
             None
         }
-    }
-
-    #[deprecated(
-        since = "10.0.0",
-        note = "Renamed, use `get_deterministic_address_translation_info` which is consistent with other function names in `CpuId`."
-    )]
-    pub fn deterministic_address_translation_info(&self) -> Option<DatIter> {
-        self.get_deterministic_address_translation_info()
-    }
-
-    /// Extended functionality of CPU described here (including more supported features).
-    /// This also contains a more detailed CPU model identifier.
-    #[deprecated(
-        since = "10.0.0",
-        note = "Removed due to added AMD support. Use functions `TODO1`, `TODO2` ... in `CpuId` to query individual extended function leafs directly instead."
-    )]
-    pub fn get_extended_function_info(&self) -> Option<ExtendedFunctionInfo> {
-        let res = self.read.cpuid1(EAX_EXTENDED_FUNCTION_INFO);
-
-        if res.eax == 0 {
-            return None;
-        }
-
-        let mut ef = ExtendedFunctionInfo {
-            max_eax_value: res.eax - EAX_EXTENDED_FUNCTION_INFO,
-            data: [
-                CpuIdResult {
-                    eax: res.eax,
-                    ebx: res.ebx,
-                    ecx: res.ecx,
-                    edx: res.edx,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-                CpuIdResult {
-                    eax: 0,
-                    ebx: 0,
-                    ecx: 0,
-                    edx: 0,
-                },
-            ],
-        };
-
-        let max_eax_value = min(ef.max_eax_value + 1, ef.data.len() as u32);
-        for i in 1..max_eax_value {
-            ef.data[i as usize] = self.read.cpuid1(EAX_EXTENDED_FUNCTION_INFO + i);
-        }
-
-        Some(ef)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,6 @@ use core::mem::size_of;
 use core::slice;
 use core::str;
 
-use alloc::vec::Vec;
 pub use extended::*;
 
 #[cfg(not(test))]
@@ -1572,7 +1571,6 @@ impl Debug for ProcessorSerial {
     }
 }
 
-#[derive(Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct FeatureInfo {
     vendor: Vendor,

--- a/src/tests/i5_3337u.rs
+++ b/src/tests/i5_3337u.rs
@@ -704,6 +704,26 @@ fn extended_functions() {
         ],
     };
 
+    assert!(ef.extended_signature().unwrap() == 0x0);
+    assert!(ef.cache_line_size().unwrap() == 64);
+    assert!(ef.l2_associativity().unwrap() == L2Associativity::EightWay);
+    assert!(ef.cache_size().unwrap() == 256);
+    assert!(ef.physical_address_bits().unwrap() == 36);
+    assert!(ef.linear_address_bits().unwrap() == 48);
+}
+
+#[test]
+fn extended_processor_feature_identifiers() {
+    let ef = ExtendedProcessorFeatureIdentifiers::new(
+        Vendor::Intel,
+        CpuIdResult {
+            eax: 0,
+            ebx: 0,
+            ecx: 1,
+            edx: 672139264,
+        },
+    );
+
     assert!(ef.has_lahf_sahf());
     assert!(!ef.has_lzcnt());
     assert!(!ef.has_prefetchw());
@@ -712,14 +732,6 @@ fn extended_functions() {
     assert!(!ef.has_1gib_pages());
     assert!(ef.has_rdtscp());
     assert!(ef.has_64bit_mode());
-    assert!(ef.has_invariant_tsc());
-
-    assert!(ef.extended_signature().unwrap() == 0x0);
-    assert!(ef.cache_line_size().unwrap() == 64);
-    assert!(ef.l2_associativity().unwrap() == L2Associativity::EightWay);
-    assert!(ef.cache_size().unwrap() == 256);
-    assert!(ef.physical_address_bits().unwrap() == 36);
-    assert!(ef.linear_address_bits().unwrap() == 48);
 }
 
 #[test]

--- a/src/tests/i5_3337u.rs
+++ b/src/tests/i5_3337u.rs
@@ -13,6 +13,7 @@ fn genuine_intel() {
 #[test]
 fn feature_info() {
     let finfo = FeatureInfo {
+        vendor: Vendor::Intel,
         eax: 198313,
         ebx: 34605056,
         edx_ecx: FeatureInfoFlags {
@@ -20,11 +21,11 @@ fn feature_info() {
         },
     };
 
-    assert!(finfo.model_id() == 10);
+    assert!(finfo.base_model_id() == 10);
     assert!(finfo.extended_model_id() == 3);
     assert!(finfo.stepping_id() == 9);
     assert!(finfo.extended_family_id() == 0);
-    assert!(finfo.family_id() == 6);
+    assert!(finfo.base_family_id() == 6);
     assert!(finfo.stepping_id() == 9);
     assert!(finfo.brand_index() == 0);
 

--- a/src/tests/i5_3337u.rs
+++ b/src/tests/i5_3337u.rs
@@ -704,10 +704,6 @@ fn extended_functions() {
         ],
     };
 
-    assert_eq!(
-        ef.processor_brand_string().unwrap(),
-        "       Intel(R) Core(TM) i5-3337U CPU @ 1.80GHz"
-    );
     assert!(ef.has_lahf_sahf());
     assert!(!ef.has_lzcnt());
     assert!(!ef.has_prefetchw());
@@ -724,6 +720,35 @@ fn extended_functions() {
     assert!(ef.cache_size().unwrap() == 256);
     assert!(ef.physical_address_bits().unwrap() == 36);
     assert!(ef.linear_address_bits().unwrap() == 48);
+}
+
+#[test]
+fn processor_brand_string() {
+    let pbs = crate::extended::ProcessorBrandString::new([
+        CpuIdResult {
+            eax: 538976288,
+            ebx: 1226842144,
+            ecx: 1818588270,
+            edx: 539578920,
+        },
+        CpuIdResult {
+            eax: 1701998403,
+            ebx: 692933672,
+            ecx: 758475040,
+            edx: 926102323,
+        },
+        CpuIdResult {
+            eax: 1346576469,
+            ebx: 541073493,
+            ecx: 808988209,
+            edx: 8013895,
+        },
+    ]);
+
+    assert_eq!(
+        pbs.as_str(),
+        "       Intel(R) Core(TM) i5-3337U CPU @ 1.80GHz"
+    );
 }
 
 #[cfg(test)]

--- a/src/tests/ryzen_matisse.rs
+++ b/src/tests/ryzen_matisse.rs
@@ -88,8 +88,8 @@ fn version_info() {
     let cpuid = CpuId::with_cpuid_fn(cpuid_reader);
     let f = cpuid.get_feature_info().expect("Need to find feature info");
 
-    assert_eq!(f.family_id(), 0xf);
-    assert_eq!(f.model_id(), 0x1);
+    assert_eq!(f.base_family_id(), 0xf);
+    assert_eq!(f.base_model_id(), 0x1);
     assert_eq!(f.stepping_id(), 0x0);
     assert_eq!(f.extended_family_id(), 0x8);
     assert_eq!(f.extended_model_id(), 0x7);

--- a/src/tests/ryzen_matisse.rs
+++ b/src/tests/ryzen_matisse.rs
@@ -1,9 +1,615 @@
-use crate::{CpuId, CpuIdResult, TopologyType};
+use crate::{Associativity, CpuId, CpuIdResult, TopologyType};
 use phf::phf_map;
 
 /// Raw dump of ryzen mantisse cpuid values.
 ///
-// Key format is (eax << 32 | ecx) e.g., two 32 bit values packed in one 64 bit value
+/// Key format is (eax << 32 | ecx) e.g., two 32 bit values packed in one 64 bit value
+///
+///
+/// # Representation of Hex Values
+///
+/// ```log
+///   vendor_id = "AuthenticAMD"
+///   version information (1/eax):
+///      processor type  = primary processor (0)
+///      family          = 0xf (15)
+///      model           = 0x1 (1)
+///      stepping id     = 0x0 (0)
+///      extended family = 0x8 (8)
+///      extended model  = 0x7 (7)
+///      (family synth)  = 0x17 (23)
+///      (model synth)   = 0x71 (113)
+///      (simple synth)  = AMD Ryzen (Matisse B0) [Zen 2], 7nm
+///   miscellaneous (1/ebx):
+///      process local APIC physical ID = 0xa (10)
+///      cpu count                      = 0xc (12)
+///      CLFLUSH line size              = 0x8 (8)
+///      brand index                    = 0x0 (0)
+///   brand id = 0x00 (0): unknown
+///   feature information (1/edx):
+///      x87 FPU on chip                        = true
+///      VME: virtual-8086 mode enhancement     = true
+///      DE: debugging extensions               = true
+///      PSE: page size extensions              = true
+///      TSC: time stamp counter                = true
+///      RDMSR and WRMSR support                = true
+///      PAE: physical address extensions       = true
+///      MCE: machine check exception           = true
+///      CMPXCHG8B inst.                        = true
+///      APIC on chip                           = true
+///      SYSENTER and SYSEXIT                   = true
+///      MTRR: memory type range registers      = true
+///      PTE global bit                         = true
+///      MCA: machine check architecture        = true
+///      CMOV: conditional move/compare instr   = true
+///      PAT: page attribute table              = true
+///      PSE-36: page size extension            = true
+///      PSN: processor serial number           = false
+///      CLFLUSH instruction                    = true
+///      DS: debug store                        = false
+///      ACPI: thermal monitor and clock ctrl   = false
+///      MMX Technology                         = true
+///      FXSAVE/FXRSTOR                         = true
+///      SSE extensions                         = true
+///      SSE2 extensions                        = true
+///      SS: self snoop                         = false
+///      hyper-threading / multi-core supported = true
+///      TM: therm. monitor                     = false
+///      IA64                                   = false
+///      PBE: pending break event               = false
+///   feature information (1/ecx):
+///      PNI/SSE3: Prescott New Instructions     = true
+///      PCLMULDQ instruction                    = true
+///      DTES64: 64-bit debug store              = false
+///      MONITOR/MWAIT                           = true
+///      CPL-qualified debug store               = false
+///      VMX: virtual machine extensions         = false
+///      SMX: safer mode extensions              = false
+///      Enhanced Intel SpeedStep Technology     = false
+///      TM2: thermal monitor 2                  = false
+///      SSSE3 extensions                        = true
+///      context ID: adaptive or shared L1 data  = false
+///      SDBG: IA32_DEBUG_INTERFACE              = false
+///      FMA instruction                         = true
+///      CMPXCHG16B instruction                  = true
+///      xTPR disable                            = false
+///      PDCM: perfmon and debug                 = false
+///      PCID: process context identifiers       = false
+///      DCA: direct cache access                = false
+///      SSE4.1 extensions                       = true
+///      SSE4.2 extensions                       = true
+///      x2APIC: extended xAPIC support          = false
+///      MOVBE instruction                       = true
+///      POPCNT instruction                      = true
+///      time stamp counter deadline             = false
+///      AES instruction                         = true
+///      XSAVE/XSTOR states                      = true
+///      OS-enabled XSAVE/XSTOR                  = true
+///      AVX: advanced vector extensions         = true
+///      F16C half-precision convert instruction = true
+///      RDRAND instruction                      = true
+///      hypervisor guest status                 = false
+///   cache and TLB information (2):
+///   processor serial number = 0087-0F10-0000-0000-0000-0000
+///   MONITOR/MWAIT (5):
+///      smallest monitor-line size (bytes)       = 0x40 (64)
+///      largest monitor-line size (bytes)        = 0x40 (64)
+///      enum of Monitor-MWAIT exts supported     = true
+///      supports intrs as break-event for MWAIT  = true
+///      number of C0 sub C-states using MWAIT    = 0x1 (1)
+///      number of C1 sub C-states using MWAIT    = 0x1 (1)
+///      number of C2 sub C-states using MWAIT    = 0x0 (0)
+///      number of C3 sub C-states using MWAIT    = 0x0 (0)
+///      number of C4 sub C-states using MWAIT    = 0x0 (0)
+///      number of C5 sub C-states using MWAIT    = 0x0 (0)
+///      number of C6 sub C-states using MWAIT    = 0x0 (0)
+///      number of C7 sub C-states using MWAIT    = 0x0 (0)
+///   Thermal and Power Management Features (6):
+///      digital thermometer                     = false
+///      Intel Turbo Boost Technology            = false
+///      ARAT always running APIC timer          = true
+///      PLN power limit notification            = false
+///      ECMD extended clock modulation duty     = false
+///      PTM package thermal management          = false
+///      HWP base registers                      = false
+///      HWP notification                        = false
+///      HWP activity window                     = false
+///      HWP energy performance preference       = false
+///      HWP package level request               = false
+///      HDC base registers                      = false
+///      Intel Turbo Boost Max Technology 3.0    = false
+///      HWP capabilities                        = false
+///      HWP PECI override                       = false
+///      flexible HWP                            = false
+///      IA32_HWP_REQUEST MSR fast access mode   = false
+///      HW_FEEDBACK                             = false
+///      ignoring idle logical processor HWP req = false
+///      digital thermometer thresholds          = 0x0 (0)
+///      hardware coordination feedback          = true
+///      ACNT2 available                         = false
+///      performance-energy bias capability      = false
+///      performance capability reporting        = false
+///      energy efficiency capability reporting  = false
+///      size of feedback struct (4KB pages)     = 0x0 (0)
+///      index of CPU's row in feedback struct   = 0x0 (0)
+///   extended feature flags (7):
+///      FSGSBASE instructions                    = true
+///      IA32_TSC_ADJUST MSR supported            = false
+///      SGX: Software Guard Extensions supported = false
+///      BMI1 instructions                        = true
+///      HLE hardware lock elision                = false
+///      AVX2: advanced vector extensions 2       = true
+///      FDP_EXCPTN_ONLY                          = false
+///      SMEP supervisor mode exec protection     = true
+///      BMI2 instructions                        = true
+///      enhanced REP MOVSB/STOSB                 = false
+///      INVPCID instruction                      = false
+///      RTM: restricted transactional memory     = false
+///      RDT-CMT/PQoS cache monitoring            = true
+///      deprecated FPU CS/DS                     = false
+///      MPX: intel memory protection extensions  = false
+///      RDT-CAT/PQE cache allocation             = true
+///      AVX512F: AVX-512 foundation instructions = false
+///      AVX512DQ: double & quadword instructions = false
+///      RDSEED instruction                       = true
+///      ADX instructions                         = true
+///      SMAP: supervisor mode access prevention  = true
+///      AVX512IFMA: fused multiply add           = false
+///      PCOMMIT instruction                      = false
+///      CLFLUSHOPT instruction                   = true
+///      CLWB instruction                         = true
+///      Intel processor trace                    = false
+///      AVX512PF: prefetch instructions          = false
+///      AVX512ER: exponent & reciprocal instrs   = false
+///      AVX512CD: conflict detection instrs      = false
+///      SHA instructions                         = true
+///      AVX512BW: byte & word instructions       = false
+///      AVX512VL: vector length                  = false
+///      PREFETCHWT1                              = false
+///      AVX512VBMI: vector byte manipulation     = false
+///      UMIP: user-mode instruction prevention   = true
+///      PKU protection keys for user-mode        = false
+///      OSPKE CR4.PKE and RDPKRU/WRPKRU          = false
+///      WAITPKG instructions                     = false
+///      AVX512_VBMI2: byte VPCOMPRESS, VPEXPAND  = false
+///      CET_SS: CET shadow stack                 = false
+///      GFNI: Galois Field New Instructions      = false
+///      VAES instructions                        = false
+///      VPCLMULQDQ instruction                   = false
+///      AVX512_VNNI: neural network instructions = false
+///      AVX512_BITALG: bit count/shiffle         = false
+///      TME: Total Memory Encryption             = false
+///      AVX512: VPOPCNTDQ instruction            = false
+///      5-level paging                           = false
+///      BNDLDX/BNDSTX MAWAU value in 64-bit mode = 0x0 (0)
+///      RDPID: read processor D supported        = true
+///      CLDEMOTE supports cache line demote      = false
+///      MOVDIRI instruction                      = false
+///      MOVDIR64B instruction                    = false
+///      ENQCMD instruction                       = false
+///      SGX_LC: SGX launch config supported      = false
+///      AVX512_4VNNIW: neural network instrs     = false
+///      AVX512_4FMAPS: multiply acc single prec  = false
+///      fast short REP MOV                       = false
+///      AVX512_VP2INTERSECT: intersect mask regs = false
+///      VERW md-clear microcode support          = false
+///      hybrid part                              = false
+///      PCONFIG instruction                      = false
+///      CET_IBT: CET indirect branch tracking    = false
+///      IBRS/IBPB: indirect branch restrictions  = false
+///      STIBP: 1 thr indirect branch predictor   = false
+///      L1D_FLUSH: IA32_FLUSH_CMD MSR            = false
+///      IA32_ARCH_CAPABILITIES MSR               = false
+///      IA32_CORE_CAPABILITIES MSR               = false
+///      SSBD: speculative store bypass disable   = false
+///   Direct Cache Access Parameters (9):
+///      PLATFORM_DCA_CAP MSR bits = 0
+///   Architecture Performance Monitoring Features (0xa/eax):
+///      version ID                               = 0x0 (0)
+///      number of counters per logical processor = 0x0 (0)
+///      bit width of counter                     = 0x0 (0)
+///      length of EBX bit vector                 = 0x0 (0)
+///   Architecture Performance Monitoring Features (0xa/ebx):
+///      core cycle event not available           = false
+///      instruction retired event not available  = false
+///      reference cycles event not available     = false
+///      last-level cache ref event not available = false
+///      last-level cache miss event not avail    = false
+///      branch inst retired event not available  = false
+///      branch mispred retired event not avail   = false
+///   Architecture Performance Monitoring Features (0xa/edx):
+///      number of fixed counters    = 0x0 (0)
+///      bit width of fixed counters = 0x0 (0)
+///      anythread deprecation       = false
+///   x2APIC features / processor topology (0xb):
+///      extended APIC ID                      = 10
+///      --- level 0 ---
+///      level number                          = 0x0 (0)
+///      level type                            = thread (1)
+///      bit width of level                    = 0x1 (1)
+///      number of logical processors at level = 0x2 (2)
+///      --- level 1 ---
+///      level number                          = 0x1 (1)
+///      level type                            = core (2)
+///      bit width of level                    = 0x7 (7)
+///      number of logical processors at level = 0xc (12)
+///   XSAVE features (0xd/0):
+///      XCR0 lower 32 bits valid bit field mask = 0x00000207
+///      XCR0 upper 32 bits valid bit field mask = 0x00000000
+///         XCR0 supported: x87 state            = true
+///         XCR0 supported: SSE state            = true
+///         XCR0 supported: AVX state            = true
+///         XCR0 supported: MPX BNDREGS          = false
+///         XCR0 supported: MPX BNDCSR           = false
+///         XCR0 supported: AVX-512 opmask       = false
+///         XCR0 supported: AVX-512 ZMM_Hi256    = false
+///         XCR0 supported: AVX-512 Hi16_ZMM     = false
+///         IA32_XSS supported: PT state         = false
+///         XCR0 supported: PKRU state           = true
+///         XCR0 supported: CET_U state          = false
+///         XCR0 supported: CET_S state          = false
+///         IA32_XSS supported: HDC state        = false
+///      bytes required by fields in XCR0        = 0x00000340 (832)
+///      bytes required by XSAVE/XRSTOR area     = 0x00000380 (896)
+///   XSAVE features (0xd/1):
+///      XSAVEOPT instruction                        = true
+///      XSAVEC instruction                          = true
+///      XGETBV instruction                          = true
+///      XSAVES/XRSTORS instructions                 = true
+///      SAVE area size in bytes                     = 0x00000340 (832)
+///      IA32_XSS lower 32 bits valid bit field mask = 0x00000000
+///      IA32_XSS upper 32 bits valid bit field mask = 0x00000000
+///   AVX/YMM features (0xd/2):
+///      AVX/YMM save state byte size             = 0x00000100 (256)
+///      AVX/YMM save state byte offset           = 0x00000240 (576)
+///      supported in IA32_XSS or XCR0            = XCR0 (user state)
+///      64-byte alignment in compacted XSAVE     = false
+///   PKRU features (0xd/9):
+///      PKRU save state byte size                = 0x00000040 (64)
+///      PKRU save state byte offset              = 0x00000340 (832)
+///      supported in IA32_XSS or XCR0            = XCR0 (user state)
+///      64-byte alignment in compacted XSAVE     = false
+///   Quality of Service Monitoring Resource Type (0xf/0):
+///      Maximum range of RMID = 255
+///      supports L3 cache QoS monitoring = true
+///   L3 Cache Quality of Service Monitoring (0xf/1):
+///      Conversion factor from IA32_QM_CTR to bytes = 64
+///      Maximum range of RMID                       = 255
+///      supports L3 occupancy monitoring       = true
+///      supports L3 total bandwidth monitoring = true
+///      supports L3 local bandwidth monitoring = true
+///   Resource Director Technology Allocation (0x10/0):
+///      L3 cache allocation technology supported = true
+///      L2 cache allocation technology supported = false
+///      memory bandwidth allocation supported    = false
+///   L3 Cache Allocation Technology (0x10/1):
+///      length of capacity bit mask              = 0x10 (16)
+///      Bit-granular map of isolation/contention = 0x00000000
+///      infrequent updates of COS                = false
+///      code and data prioritization supported   = true
+///      highest COS number supported             = 0xf (15)
+///   extended processor signature (0x80000001/eax):
+///      family/generation = 0xf (15)
+///      model           = 0x1 (1)
+///      stepping id     = 0x0 (0)
+///      extended family = 0x8 (8)
+///      extended model  = 0x7 (7)
+///      (family synth)  = 0x17 (23)
+///      (model synth)   = 0x71 (113)
+///      (simple synth)  = AMD Ryzen (Matisse B0) [Zen 2], 7nm
+///   extended feature flags (0x80000001/edx):
+///      x87 FPU on chip                       = true
+///      virtual-8086 mode enhancement         = true
+///      debugging extensions                  = true
+///      page size extensions                  = true
+///      time stamp counter                    = true
+///      RDMSR and WRMSR support               = true
+///      physical address extensions           = true
+///      machine check exception               = true
+///      CMPXCHG8B inst.                       = true
+///      APIC on chip                          = true
+///      SYSCALL and SYSRET instructions       = true
+///      memory type range registers           = true
+///      global paging extension               = true
+///      machine check architecture            = true
+///      conditional move/compare instruction  = true
+///      page attribute table                  = true
+///      page size extension                   = true
+///      multiprocessing capable               = false
+///      no-execute page protection            = true
+///      AMD multimedia instruction extensions = true
+///      MMX Technology                        = true
+///      FXSAVE/FXRSTOR                        = true
+///      SSE extensions                        = true
+///      1-GB large page support               = true
+///      RDTSCP                                = true
+///      long mode (AA-64)                     = true
+///      3DNow! instruction extensions         = false
+///      3DNow! instructions                   = false
+///   extended brand id (0x80000001/ebx):
+///      raw     = 0x20000000 (536870912)
+///      BrandId = 0x0 (0)
+///      PkgType = AM4 (2)
+///   AMD feature flags (0x80000001/ecx):
+///      LAHF/SAHF supported in 64-bit mode     = true
+///      CMP Legacy                             = true
+///      SVM: secure virtual machine            = true
+///      extended APIC space                    = true
+///      AltMovCr8                              = true
+///      LZCNT advanced bit manipulation        = true
+///      SSE4A support                          = true
+///      misaligned SSE mode                    = true
+///      3DNow! PREFETCH/PREFETCHW instructions = true
+///      OS visible workaround                  = true
+///      instruction based sampling             = true
+///      XOP support                            = false
+///      SKINIT/STGI support                    = true
+///      watchdog timer support                 = true
+///      lightweight profiling support          = false
+///      4-operand FMA instruction              = false
+///      TCE: translation cache extension       = true
+///      NodeId MSR C001100C                    = false
+///      TBM support                            = false
+///      topology extensions                    = true
+///      core performance counter extensions    = true
+///      NB/DF performance counter extensions   = true
+///      data breakpoint extension              = true
+///      performance time-stamp counter support = false
+///      LLC performance counter extensions     = true
+///      MWAITX/MONITORX supported              = true
+///      Address mask extension support         = true
+///   brand = "AMD Ryzen 5 3600X 6-Core Processor             "
+///   L1 TLB/cache information: 2M/4M pages & L1 TLB (0x80000005/eax):
+///      instruction # entries     = 0x40 (64)
+///      instruction associativity = 0xff (255)
+///      data # entries            = 0x40 (64)
+///      data associativity        = 0xff (255)
+///   L1 TLB/cache information: 4K pages & L1 TLB (0x80000005/ebx):
+///      instruction # entries     = 0x40 (64)
+///      instruction associativity = 0xff (255)
+///      data # entries            = 0x40 (64)
+///      data associativity        = 0xff (255)
+///   L1 data cache information (0x80000005/ecx):
+///      line size (bytes) = 0x40 (64)
+///      lines per tag     = 0x1 (1)
+///      associativity     = 0x8 (8)
+///      size (KB)         = 0x20 (32)
+///   L1 instruction cache information (0x80000005/edx):
+///      line size (bytes) = 0x40 (64)
+///      lines per tag     = 0x1 (1)
+///      associativity     = 0x8 (8)
+///      size (KB)         = 0x20 (32)
+///   L2 TLB/cache information: 2M/4M pages & L2 TLB (0x80000006/eax):
+///      instruction # entries     = 0x400 (1024)
+///      instruction associativity = 8-way (6)
+///      data # entries            = 0x800 (2048)
+///      data associativity        = 4-way (4)
+///   L2 TLB/cache information: 4K pages & L2 TLB (0x80000006/ebx):
+///      instruction # entries     = 0x400 (1024)
+///      instruction associativity = 8-way (6)
+///      data # entries            = 0x800 (2048)
+///      data associativity        = 8-way (6)
+///   L2 unified cache information (0x80000006/ecx):
+///      line size (bytes) = 0x40 (64)
+///      lines per tag     = 0x1 (1)
+///      associativity     = 8-way (6)
+///      size (KB)         = 0x200 (512)
+///   L3 cache information (0x80000006/edx):
+///      line size (bytes)     = 0x40 (64)
+///      lines per tag         = 0x1 (1)
+///      associativity         = 0x9 (9)
+///      size (in 512KB units) = 0x40 (64)
+///   RAS Capability (0x80000007/ebx):
+///      MCA overflow recovery support = true
+///      SUCCOR support                = true
+///      HWA: hardware assert support  = false
+///      scalable MCA support          = true
+///   Advanced Power Management Features (0x80000007/ecx):
+///      CmpUnitPwrSampleTimeRatio = 0x0 (0)
+///   Advanced Power Management Features (0x80000007/edx):
+///      TS: temperature sensing diode           = true
+///      FID: frequency ID control               = false
+///      VID: voltage ID control                 = false
+///      TTP: thermal trip                       = true
+///      TM: thermal monitor                     = true
+///      STC: software thermal control           = false
+///      100 MHz multiplier control              = false
+///      hardware P-State control                = true
+///      TscInvariant                            = true
+///      CPB: core performance boost             = true
+///      read-only effective frequency interface = true
+///      processor feedback interface            = false
+///      APM power reporting                     = false
+///      connected standby                       = true
+///      RAPL: running average power limit       = true
+///   Physical Address and Linear Address Size (0x80000008/eax):
+///      maximum physical address bits         = 0x30 (48)
+///      maximum linear (virtual) address bits = 0x30 (48)
+///      maximum guest physical address bits   = 0x0 (0)
+///   Extended Feature Extensions ID (0x80000008/ebx):
+///      CLZERO instruction                       = true
+///      instructions retired count support       = true
+///      always save/restore error pointers       = true
+///      RDPRU instruction                        = true
+///      memory bandwidth enforcement             = true
+///      WBNOINVD instruction                     = true
+///      IBPB: indirect branch prediction barrier = true
+///      IBRS: indirect branch restr speculation  = false
+///      STIBP: 1 thr indirect branch predictor   = true
+///      STIBP always on preferred mode           = true
+///      ppin processor id number supported       = false
+///      SSBD: speculative store bypass disable   = true
+///      virtualized SSBD                         = false
+///      SSBD fixed in hardware                   = false
+///   Size Identifiers (0x80000008/ecx):
+///      number of threads                   = 0xc (12)
+///      ApicIdCoreIdSize                    = 0x7 (7)
+///      performance time-stamp counter size = 0x0 (0)
+///   Feature Extended Size (0x80000008/edx):
+///      RDPRU instruction max input support = 0x1 (1)
+///   SVM Secure Virtual Machine (0x8000000a/eax):
+///      SvmRev: SVM revision = 0x1 (1)
+///   SVM Secure Virtual Machine (0x8000000a/edx):
+///      nested paging                           = true
+///      LBR virtualization                      = true
+///      SVM lock                                = true
+///      NRIP save                               = true
+///      MSR based TSC rate control              = true
+///      VMCB clean bits support                 = true
+///      flush by ASID                           = true
+///      decode assists                          = true
+///      SSSE3/SSE5 opcode set disable           = false
+///      pause intercept filter                  = true
+///      pause filter threshold                  = true
+///      AVIC: AMD virtual interrupt controller  = true
+///      virtualized VMLOAD/VMSAVE               = true
+///      virtualized global interrupt flag (GIF) = true
+///      GMET: guest mode execute trap           = true
+///      guest Spec_ctl support                  = true
+///   NASID: number of address space identifiers = 0x8000 (32768):
+///   L1 TLB information: 1G pages (0x80000019/eax):
+///      instruction # entries     = 0x40 (64)
+///      instruction associativity = full (15)
+///      data # entries            = 0x40 (64)
+///      data associativity        = full (15)
+///   L2 TLB information: 1G pages (0x80000019/ebx):
+///      instruction # entries     = 0x0 (0)
+///      instruction associativity = L2 off (0)
+///      data # entries            = 0x0 (0)
+///      data associativity        = L2 off (0)
+///   SVM Secure Virtual Machine (0x8000001a/eax):
+///      128-bit SSE executed full-width = false
+///      MOVU* better than MOVL*/MOVH*   = true
+///      256-bit SSE executed full-width = true
+///   Instruction Based Sampling Identifiers (0x8000001b/eax):
+///      IBS feature flags valid                  = true
+///      IBS fetch sampling                       = true
+///      IBS execution sampling                   = true
+///      read write of op counter                 = true
+///      op counting mode                         = true
+///      branch target address reporting          = true
+///      IbsOpCurCnt and IbsOpMaxCnt extend 7     = true
+///      invalid RIP indication support           = true
+///      fused branch micro-op indication support = true
+///      IBS fetch control extended MSR support   = true
+///      IBS op data 4 MSR support                = false
+///   Lightweight Profiling Capabilities: Availability (0x8000001c/eax):
+///      lightweight profiling                  = false
+///      LWPVAL instruction                     = false
+///      instruction retired event              = false
+///      branch retired event                   = false
+///      DC miss event                          = false
+///      core clocks not halted event           = false
+///      core reference clocks not halted event = false
+///      interrupt on threshold overflow        = false
+///   Lightweight Profiling Capabilities: Supported (0x8000001c/edx):
+///      lightweight profiling                  = false
+///      LWPVAL instruction                     = false
+///      instruction retired event              = false
+///      branch retired event                   = false
+///      DC miss event                          = false
+///      core clocks not halted event           = false
+///      core reference clocks not halted event = false
+///      interrupt on threshold overflow        = false
+///   Lightweight Profiling Capabilities (0x8000001c/ebx):
+///      LWPCB byte size             = 0x0 (0)
+///      event record byte size      = 0x0 (0)
+///      maximum EventId             = 0x0 (0)
+///      EventInterval1 field offset = 0x0 (0)
+///   Lightweight Profiling Capabilities (0x8000001c/ecx):
+///      latency counter bit size          = 0x0 (0)
+///      data cache miss address valid     = false
+///      amount cache latency is rounded   = 0x0 (0)
+///      LWP implementation version        = 0x0 (0)
+///      event ring buffer size in records = 0x0 (0)
+///      branch prediction filtering       = false
+///      IP filtering                      = false
+///      cache level filtering             = false
+///      cache latency filteing            = false
+///   Cache Properties (0x8000001d):
+///      --- cache 0 ---
+///      type                            = data (1)
+///      level                           = 0x1 (1)
+///      self-initializing               = true
+///      fully associative               = false
+///      extra cores sharing this cache  = 0x1 (1)
+///      line size in bytes              = 0x40 (64)
+///      physical line partitions        = 0x1 (1)
+///      number of ways                  = 0x8 (8)
+///      number of sets                  = 64
+///      write-back invalidate           = false
+///      cache inclusive of lower levels = false
+///      (synth size)                    = 32768 (32 KB)
+///      --- cache 1 ---
+///      type                            = instruction (2)
+///      level                           = 0x1 (1)
+///      self-initializing               = true
+///      fully associative               = false
+///      extra cores sharing this cache  = 0x1 (1)
+///      line size in bytes              = 0x40 (64)
+///      physical line partitions        = 0x1 (1)
+///      number of ways                  = 0x8 (8)
+///      number of sets                  = 64
+///      write-back invalidate           = false
+///      cache inclusive of lower levels = false
+///      (synth size)                    = 32768 (32 KB)
+///      --- cache 2 ---
+///      type                            = unified (3)
+///      level                           = 0x2 (2)
+///      self-initializing               = true
+///      fully associative               = false
+///      extra cores sharing this cache  = 0x1 (1)
+///      line size in bytes              = 0x40 (64)
+///      physical line partitions        = 0x1 (1)
+///      number of ways                  = 0x8 (8)
+///      number of sets                  = 1024
+///      write-back invalidate           = false
+///      cache inclusive of lower levels = true
+///      (synth size)                    = 524288 (512 KB)
+///      --- cache 3 ---
+///      type                            = unified (3)
+///      level                           = 0x3 (3)
+///      self-initializing               = true
+///      fully associative               = false
+///      extra cores sharing this cache  = 0x5 (5)
+///      line size in bytes              = 0x40 (64)
+///      physical line partitions        = 0x1 (1)
+///      number of ways                  = 0x10 (16)
+///      number of sets                  = 16384
+///      write-back invalidate           = true
+///      cache inclusive of lower levels = false
+///      (synth size)                    = 16777216 (16 MB)
+///   extended APIC ID = 10
+///   Core Identifiers (0x8000001e/ebx):
+///      core ID          = 0x5 (5)
+///      threads per core = 0x2 (2)
+///   Node Identifiers (0x8000001e/ecx):
+///      node ID             = 0x0 (0)
+///      nodes per processor = 0x1 (1)
+///   AMD Secure Encryption (0x8000001f):
+///      SME: secure memory encryption support    = true
+///      SEV: secure encrypted virtualize support = true
+///      VM page flush MSR support                = true
+///      SEV-ES: SEV encrypted state support      = true
+///      encryption bit position in PTE           = 0x2f (47)
+///      physical address space width reduction   = 0x5 (5)
+///      number of SEV-enabled guests supported   = 0x1fd (509)
+///      minimum SEV guest ASID                   = 0x1 (1)
+///   PQoS Enforcement for Memory Bandwidth (0x80000020):
+///      memory bandwidth enforcement support = true
+///      capacity bitmask length              = 0xc (12)
+///      number of classes of service         = 0xf (15)
+///   (instruction supported synth):
+///      CMPXCHG8B                = true
+///      conditional move/compare = true
+///      PREFETCH/PREFETCHW       = true
+///   (multi-processing synth) = multi-core (c=12)
+///   (multi-processing method) = AMD
+///   (APIC widths synth): CORE_width=3 SMT_width=1
+///   (APIC synth): PKG_ID=0 CORE_ID=5 SMT_ID=0
+///   (uarch synth) = AMD Zen 2, 7nm
+///   (synth) = AMD Ryzen (Matisse B0) [Zen 2], 7nm
+/// ```
 static CPUID_VALUE_MAP: phf::Map<u64, CpuIdResult> = phf_map! {
     0x00000000_00000000u64 => CpuIdResult { eax: 0x00000010, ebx: 0x68747541, ecx: 0x444d4163, edx: 0x69746e65 },
     0x00000001_00000000u64 => CpuIdResult { eax: 0x00870f10, ebx: 0x000c0800, ecx: 0x7ed8320b, edx: 0x178bfbff },
@@ -371,6 +977,184 @@ fn rdt_allocation_info() {
     assert_eq!(l3c.isolation_bitmap(), 0x0);
     assert_eq!(l3c.highest_cos(), 15);
     assert!(l3c.has_code_data_prioritization());
+}
+
+#[test]
+fn extended_processor_and_feature_identifiers() {
+    let cpuid = CpuId::with_cpuid_fn(cpuid_reader);
+    let e = cpuid
+        .get_extended_processor_and_feature_identifiers()
+        .expect("Leaf is supported");
+
+    assert_eq!(e.pkg_type(), 0x2);
+    assert_eq!(e.brand_id(), 0x0);
+
+    assert!(e.has_lahf_sahf());
+    assert!(e.has_cmp_legacy());
+    assert!(e.has_svm());
+    assert!(e.has_ext_apic_space());
+    assert!(e.has_alt_mov_cr8());
+    assert!(e.has_lzcnt());
+    assert!(e.has_sse4a());
+    assert!(e.has_misaligned_sse_mode());
+    assert!(e.has_prefetchw());
+    assert!(e.has_osvw());
+    assert!(e.has_ibs());
+    assert!(!e.has_xop());
+    assert!(e.has_skinit());
+    assert!(e.has_wdt());
+    assert!(!e.has_lwp());
+    assert!(!e.has_fma4());
+    assert!(!e.has_tbm());
+    assert!(e.has_topology_extensions());
+    assert!(e.has_perf_cntr_extensions());
+    assert!(e.has_nb_perf_cntr_extensions());
+    assert!(e.has_data_access_bkpt_extension());
+    assert!(!e.has_perf_tsc());
+    assert!(e.has_perf_cntr_llc_extensions());
+    assert!(e.has_monitorx_mwaitx());
+    assert!(e.has_addr_mask_extension());
+    assert!(e.has_syscall_sysret());
+    assert!(e.has_execute_disable());
+    assert!(e.has_mmx_extensions());
+    assert!(e.has_fast_fxsave_fxstor());
+    assert!(e.has_1gib_pages());
+    assert!(e.has_rdtscp());
+    assert!(e.has_64bit_mode());
+    assert!(!e.has_amd_3dnow_extensions());
+    assert!(!e.has_3dnow());
+}
+
+#[test]
+fn brand_string() {
+    let cpuid = CpuId::with_cpuid_fn(cpuid_reader);
+    let e = cpuid
+        .get_processor_brand_string()
+        .expect("Leaf is supported");
+
+    assert_eq!(
+        e.as_str(),
+        "AMD Ryzen 5 3600X 6-Core Processor             "
+    );
+}
+
+#[test]
+fn l1_tlb_cache() {
+    let cpuid = CpuId::with_cpuid_fn(cpuid_reader);
+    let e = cpuid
+        .get_l1_cache_and_tlb_info()
+        .expect("Leaf is supported");
+
+    assert_eq!(
+        e.dtlb_2m_4m_associativity(),
+        Associativity::FullyAssociative
+    );
+    assert_eq!(e.dtlb_2m_4m_size(), 64);
+
+    assert_eq!(
+        e.itlb_2m_4m_associativity(),
+        Associativity::FullyAssociative
+    );
+    assert_eq!(e.itlb_2m_4m_size(), 64);
+
+    assert_eq!(e.dtlb_4k_associativity(), Associativity::FullyAssociative);
+    assert_eq!(e.dtlb_4k_size(), 64);
+    assert_eq!(e.itlb_4k_associativity(), Associativity::FullyAssociative);
+    assert_eq!(e.itlb_4k_size(), 64);
+
+    assert_eq!(e.dcache_line_size(), 64);
+    assert_eq!(e.dcache_lines_per_tag(), 1);
+    assert_eq!(e.dcache_associativity(), Associativity::NWay(8));
+    assert_eq!(e.dcache_size(), 32);
+
+    assert_eq!(e.icache_line_size(), 64);
+    assert_eq!(e.icache_lines_per_tag(), 1);
+    assert_eq!(e.icache_associativity(), Associativity::NWay(8));
+    assert_eq!(e.icache_size(), 32);
+}
+
+#[test]
+fn l2_l3_tlb_cache() {
+    let cpuid = CpuId::with_cpuid_fn(cpuid_reader);
+    let e = cpuid
+        .get_l2_l3_cache_and_tlb_info()
+        .expect("Leaf is supported");
+
+    assert_eq!(e.itlb_2m_4m_associativity(), Associativity::NWay(8));
+    assert_eq!(e.itlb_2m_4m_size(), 1024);
+
+    assert_eq!(e.dtlb_2m_4m_associativity(), Associativity::NWay(4));
+    assert_eq!(e.dtlb_2m_4m_size(), 2048);
+
+    assert_eq!(e.itlb_4k_size(), 1024);
+    assert_eq!(e.itlb_4k_associativity(), Associativity::NWay(8));
+
+    assert_eq!(e.dtlb_4k_size(), 2048);
+    assert_eq!(e.dtlb_4k_associativity(), Associativity::NWay(8));
+
+    assert_eq!(e.l2cache_line_size(), 64);
+    assert_eq!(e.l2cache_lines_per_tag(), 1);
+    assert_eq!(e.l2cache_associativity(), Associativity::NWay(8));
+    assert_eq!(e.l2cache_size(), 0x200);
+
+    assert_eq!(e.l3cache_line_size(), 64);
+    assert_eq!(e.l3cache_lines_per_tag(), 1);
+    assert_eq!(e.l3cache_associativity(), Associativity::Unknown);
+    assert_eq!(e.l3cache_size(), 64);
+}
+
+#[test]
+fn apm() {
+    let cpuid = CpuId::with_cpuid_fn(cpuid_reader);
+    let e = cpuid
+        .get_advanced_power_mgmt_info()
+        .expect("Leaf is supported");
+
+    assert_eq!(e.cpu_pwr_sample_time_ratio(), 0x0);
+
+    assert!(e.has_mca_overflow_recovery());
+    assert!(e.has_succor());
+    assert!(!e.has_hwa());
+
+    assert!(e.has_ts());
+    assert!(!e.has_freq_id_ctrl());
+    assert!(!e.has_volt_id_ctrl());
+    assert!(e.has_thermtrip());
+    assert!(e.has_tm());
+    assert!(!e.has_100mhz_steps());
+    assert!(e.has_hw_pstate());
+    assert!(e.has_invariant_tsc());
+    assert!(e.has_cpb());
+    assert!(e.has_ro_effective_freq_iface());
+    assert!(!e.has_feedback_iface());
+    assert!(!e.has_power_reporting_iface());
+}
+
+#[test]
+fn secure_encryption() {
+    let cpuid = CpuId::with_cpuid_fn(cpuid_reader);
+    let e = cpuid
+        .get_memory_encryption_info()
+        .expect("Leaf is supported");
+
+    assert!(e.has_sme());
+    assert!(e.has_sev());
+    assert!(e.has_page_flush_msr());
+    assert!(e.has_sev_es());
+    assert!(!e.has_sev_snp());
+    assert!(!e.has_vmpl());
+    assert!(!e.has_hw_enforced_cache_coh());
+    assert!(!e.has_64bit_mode());
+    assert!(!e.has_restricted_injection());
+    assert!(!e.has_alternate_injection());
+    assert!(!e.has_debug_swap());
+    assert!(!e.has_prevent_host_ibs());
+    assert!(e.has_vte());
+
+    assert_eq!(e.c_bit_position(), 0x2f);
+    assert_eq!(e.physical_address_reduction(), 0x5);
+    assert_eq!(e.max_encrypted_guests(), 0x1fd);
+    assert_eq!(e.min_sev_no_es_asid(), 0x1);
 }
 
 #[test]

--- a/src/tests/ryzen_matisse.rs
+++ b/src/tests/ryzen_matisse.rs
@@ -381,6 +381,6 @@ fn remaining_unsupported_leafs() {
     assert!(cpuid.get_processor_trace_info().is_none());
     assert!(cpuid.get_tsc_info().is_none());
     assert!(cpuid.get_processor_frequency_info().is_none());
-    assert!(cpuid.deterministic_address_translation_info().is_none());
+    assert!(cpuid.get_deterministic_address_translation_info().is_none());
     assert!(cpuid.get_soc_vendor_info().is_none());
 }


### PR DESCRIPTION
Rough plan:
- [x] Refactor all current extended leafs and make them part of CpuId (deprecate get_extended_function_info)
- [x] Unify common extended leafs (intel and amd)
- [ ] Add the AMD specific extended leafs