### PR TITLE
Add ExtendedFeatures::has_avx512vnni().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Added ExtendedFeatures::has_avx512vnni().
+
 ## [10.2.0] - 2021-07-30
 
 ### Added

--- a/src/bin/cpuid.rs
+++ b/src/bin/cpuid.rs
@@ -746,6 +746,10 @@ fn markdown(_opts: Opts) {
                 RowGen::tuple("PKU protection keys for user-mode", info.has_pku()),
                 RowGen::tuple("OSPKE CR4.PKE and RDPKRU/WRPKRU", info.has_ospke()),
                 RowGen::tuple(
+                    "AVX512VNNI: vector neural network instructions",
+                    info.has_avx512vnni(),
+                ),
+                RowGen::tuple(
                     "BNDLDX/BNDSTX MAWAU value in 64-bit mode",
                     info.mawau_value(),
                 ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3366,6 +3366,14 @@ impl ExtendedFeatures {
         self.ecx.contains(ExtendedFeaturesEcx::OSPKE)
     }
 
+    /// AVX512VNNI
+    ///
+    /// # Platforms
+    /// ❌ AMD (reserved) ✅ Intel
+    pub fn has_avx512vnni(&self) -> bool {
+        self.ecx.contains(ExtendedFeaturesEcx::AVX512VNNI)
+    }
+
     /// RDPID and IA32_TSC_AUX are available.
     ///
     /// # Bug
@@ -3492,6 +3500,9 @@ bitflags! {
 
         /// Bit 04: OSPKE. If 1, OS has set CR4.PKE to enable protection keys (and the RDPKRU/WRPKRU instruc-tions).
         const OSPKE = 1 << 4;
+
+        /// Bit 11: AVX512_VNNI
+        const AVX512VNNI = 1 << 11;
 
         // Bits 16 - 5: Reserved.
         // Bits 21 - 17: The value of MAWAU used by the BNDLDX and BNDSTX instructions in 64-bit mode.

--- a/src/tests/ryzen_matisse.rs
+++ b/src/tests/ryzen_matisse.rs
@@ -862,6 +862,7 @@ fn extended_features() {
     assert!(e.has_umip());
     assert!(!e.has_pku());
     assert!(!e.has_ospke());
+    assert!(!e.has_avx512vnni());
     assert!(e.has_rdpid());
     assert!(!e.has_sgx_lc());
     assert_eq!(e.mawau_value(), 0x0);

--- a/src/tests/xeon_gold_6252.rs
+++ b/src/tests/xeon_gold_6252.rs
@@ -805,6 +805,7 @@ fn extended_features() {
     assert!(!e.has_umip());
     assert!(e.has_pku());
     assert!(e.has_ospke());
+    assert!(!e.has_avx512vnni());
     assert!(!e.has_rdpid());
     assert!(!e.has_sgx_lc());
     assert_eq!(e.mawau_value(), 0x0);


### PR DESCRIPTION
I added ExtendedFeatures::has_avx512vnni().
But I have no avx512vnni enabled CPUs.
How do I test this?