### PR TITLE
Fixed build when native_cpuid is not avalible on target

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -24,6 +24,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt, clippy
+          target: aarch64-unknown-linux-gnu
 
       - uses: actions-rs/cargo@v1.0.3
         with:
@@ -33,6 +34,12 @@ jobs:
         with:
           command: build
           args: --all-features
+
+      - name: Build on target without native cpuid
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --target aarch64-unknown-linux-gnu
 
       - uses: actions-rs/cargo@v1.0.3
         with:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,10 +65,11 @@ extern crate serde;
 #[macro_use]
 extern crate bitflags;
 
-#[cfg_attr(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))), has_native_cpuid)]
+#[cfg(all(feature = "serialize", not(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))))))]
+core::compile_error!("Feature `serialize` is not supported on targets that do not have native cpuid. x86 and x86_64 targets with SGX and x86 targets without SSE are consider to not have native cpuid.");
 
 /// Uses Rust's `cpuid` function from the `arch` module.
-#[cfg(has_native_cpuid)]
+#[cfg(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))))]
 pub mod native_cpuid {
     use crate::CpuIdResult;
 
@@ -108,7 +109,7 @@ mod std {
 ///
 /// First parameter is cpuid leaf (EAX register value),
 /// second optional parameter is the subleaf (ECX register value).
-#[cfg(has_native_cpuid)]
+#[cfg(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))))]
 #[macro_export]
 macro_rules! cpuid {
     ($eax:expr) => {
@@ -179,7 +180,7 @@ impl CpuIdReader {
     }
 }
 
-#[cfg(has_native_cpuid)]
+#[cfg(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))))]
 impl Default for CpuIdReader {
     fn default() -> Self {
         Self {
@@ -228,7 +229,7 @@ pub struct CpuId {
     supported_extended_leafs: u32,
 }
 
-#[cfg(has_native_cpuid)]
+#[cfg(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))))]
 impl Default for CpuId {
     fn default() -> CpuId {
         CpuId::with_cpuid_fn(native_cpuid::cpuid_count)
@@ -310,7 +311,7 @@ const EAX_SVM_FEATURES: u32 = 0x8000_000A;
 
 impl CpuId {
     /// Return new CpuId struct.
-    #[cfg(has_native_cpuid)]
+    #[cfg(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))))]
     pub fn new() -> Self {
         Self::default()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,11 +65,20 @@ extern crate serde;
 #[macro_use]
 extern crate bitflags;
 
-#[cfg(all(feature = "serialize", not(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))))))]
+#[cfg(all(
+    feature = "serialize",
+    not(any(
+        all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"),
+        all(target_arch = "x86_64", not(target_env = "sgx"))
+    ))
+))]
 core::compile_error!("Feature `serialize` is not supported on targets that do not have native cpuid. x86 and x86_64 targets with SGX and x86 targets without SSE are consider to not have native cpuid.");
 
 /// Uses Rust's `cpuid` function from the `arch` module.
-#[cfg(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))))]
+#[cfg(any(
+    all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"),
+    all(target_arch = "x86_64", not(target_env = "sgx"))
+))]
 pub mod native_cpuid {
     use crate::CpuIdResult;
 
@@ -109,7 +118,10 @@ mod std {
 ///
 /// First parameter is cpuid leaf (EAX register value),
 /// second optional parameter is the subleaf (ECX register value).
-#[cfg(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))))]
+#[cfg(any(
+    all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"),
+    all(target_arch = "x86_64", not(target_env = "sgx"))
+))]
 #[macro_export]
 macro_rules! cpuid {
     ($eax:expr) => {
@@ -180,7 +192,10 @@ impl CpuIdReader {
     }
 }
 
-#[cfg(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))))]
+#[cfg(any(
+    all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"),
+    all(target_arch = "x86_64", not(target_env = "sgx"))
+))]
 impl Default for CpuIdReader {
     fn default() -> Self {
         Self {
@@ -229,7 +244,10 @@ pub struct CpuId {
     supported_extended_leafs: u32,
 }
 
-#[cfg(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))))]
+#[cfg(any(
+    all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"),
+    all(target_arch = "x86_64", not(target_env = "sgx"))
+))]
 impl Default for CpuId {
     fn default() -> CpuId {
         CpuId::with_cpuid_fn(native_cpuid::cpuid_count)
@@ -311,7 +329,10 @@ const EAX_SVM_FEATURES: u32 = 0x8000_000A;
 
 impl CpuId {
     /// Return new CpuId struct.
-    #[cfg(any(all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"), all(target_arch = "x86_64", not(target_env = "sgx"))))]
+    #[cfg(any(
+        all(target_arch = "x86", not(target_env = "sgx"), target_feature = "sse"),
+        all(target_arch = "x86_64", not(target_env = "sgx"))
+    ))]
     pub fn new() -> Self {
         Self::default()
     }


### PR DESCRIPTION
Currently building for a non-conventional x86 target fails with:
```
   Compiling raw-cpuid v10.2.0
error[E0433]: failed to resolve: could not find `arch` in `self`
  --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/raw-cpuid-10.2.0/src/lib.rs:80:37
   |
80 |         let result = unsafe { self::arch::__cpuid_count(a, c) };
   |                                     ^^^^ could not find `arch` in `self`
```

This is because the target has no SSE, and therefore it has no native cpuid according to this create.

This PR only enables ::native_cpuid and the functions that depend on it, when the target has support for it. 

Targets that by this create are considered to not have native cpuid, can still provide there own function via `CpuId::with_cpuid_fn()`.

If `core::arch::x86::has_cpuid()` stabilizes, it could be used to detect cpuid support at runtime to better cover supported target.

With these changes I was able to output the following 😁
`Hello world from GenuineIntel Intel (R) Quark (TM) D1100 CPU @ 32MHz`
