### PR TITLE
Fixed action pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = {version = "1.0", default-features = false, optional = true}
 serde_derive = {version = "1.0", optional = true}
 serde_json = {version = "1.0", optional = true}
 termimad = {version = "0.16", optional = true}
-clap = {version = "~3.0.0-beta.2", optional = true}
+clap = {version = "3.1.6", features = ["derive"], optional = true}
 
 [target.'cfg(unix)'.dev-dependencies]
 core_affinity = "0.5.10"

--- a/src/bin/cpuid.rs
+++ b/src/bin/cpuid.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
-use clap::{Parser};
+use clap::Parser;
 use raw_cpuid::{
     cpuid, Associativity, CacheType, CpuId, CpuIdResult, DatType, ExtendedRegisterStateLocation,
     SgxSectionInfo, SoCVendorBrand, TopologyType,

--- a/src/bin/cpuid.rs
+++ b/src/bin/cpuid.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
-use clap::{AppSettings, Clap};
+use clap::{Parser};
 use raw_cpuid::{
     cpuid, Associativity, CacheType, CpuId, CpuIdResult, DatType, ExtendedRegisterStateLocation,
     SgxSectionInfo, SoCVendorBrand, TopologyType,
@@ -28,9 +28,9 @@ impl FromStr for OutputFormat {
 }
 
 /// Prints information about the current x86 CPU to stdout using the cpuid instruction.
-#[derive(Clap)]
+#[derive(Parser)]
 #[clap(version = "10.2", author = "Gerd Zellweger <mail@gerdzellweger.com>")]
-#[clap(setting = AppSettings::ColoredHelp)]
+#[clap(disable_colored_help(true))]
 struct Opts {
     /// Configures the output format.
     #[clap(short, long, default_value = "cli", possible_values = &["raw", "json", "cli", ])]

--- a/src/tests/xeon_gold_6252.rs
+++ b/src/tests/xeon_gold_6252.rs
@@ -805,7 +805,7 @@ fn extended_features() {
     assert!(!e.has_umip());
     assert!(e.has_pku());
     assert!(e.has_ospke());
-    assert!(!e.has_avx512vnni());
+    assert!(e.has_avx512vnni());
     assert!(!e.has_rdpid());
     assert!(!e.has_sgx_lc());
     assert_eq!(e.mawau_value(), 0x0);


### PR DESCRIPTION
- Updated clap to 3.1.6 and updated cpuid cli tool accordingly.
- Modified failing test, according to wikichip.org the Xeon gold 6252 does have AVX512VNNI support.