### PR TITLE
Implement AMD leaf 0x8000_001D (Cache Properties/Parameters)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,7 +455,7 @@ impl CpuId {
     /// hierarchy.
     ///
     /// # Platforms
-    /// ✅ AMD ✅ Intel
+    /// 🟡 AMD ✅ Intel
     pub fn get_cache_parameters(&self) -> Option<CacheParametersIter> {
         if self.leaf_is_supported(EAX_CACHE_PARAMETERS) || (self.vendor == Vendor::Amd && self.leaf_is_supported(EAX_CACHE_PARAMETERS_AMD)) {
             Some(CacheParametersIter {
@@ -2506,7 +2506,7 @@ bitflags! {
 /// Yields a [CacheParameter] for each cache.
 ///
 /// # Platforms
-/// ❌ AMD ✅ Intel
+/// 🟡 AMD ✅ Intel
 #[derive(Clone)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct CacheParametersIter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2670,10 +2670,10 @@ impl CacheParameter {
     }
 
     /// Complex Cache Indexing (Bit 2)
-    /// False: Direct mapped cache.
+    /// False: Direct mapped cache. (1-way)
     /// True: A complex function is used to index the cache, potentially using all address bits.
     pub fn has_complex_indexing(&self) -> bool {
-        get_bits(self.edx, 2, 2) == 1
+        get_bits(self.edx, 2, 2) == 1 || get_bits(self.ebx, 22, 31) != 0
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,7 +457,9 @@ impl CpuId {
     /// # Platforms
     /// 🟡 AMD ✅ Intel
     pub fn get_cache_parameters(&self) -> Option<CacheParametersIter> {
-        if self.leaf_is_supported(EAX_CACHE_PARAMETERS) || (self.vendor == Vendor::Amd && self.leaf_is_supported(EAX_CACHE_PARAMETERS_AMD)) {
+        if self.leaf_is_supported(EAX_CACHE_PARAMETERS)
+            || (self.vendor == Vendor::Amd && self.leaf_is_supported(EAX_CACHE_PARAMETERS_AMD))
+        {
             Some(CacheParametersIter {
                 read: self.read,
                 leaf: if self.vendor == Vendor::Amd {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2631,6 +2631,9 @@ impl CacheParameter {
     }
 
     /// Maximum number of addressable IDs for processor cores in the physical package
+    ///
+    /// # Availability
+    /// ❌ AMD ✅ Intel
     pub fn max_cores_for_package(&self) -> usize {
         (get_bits(self.eax, 26, 31) + 1) as usize
     }
@@ -2672,6 +2675,9 @@ impl CacheParameter {
     /// Complex Cache Indexing (Bit 2)
     /// False: Direct mapped cache.
     /// True: A complex function is used to index the cache, potentially using all address bits.
+    ///
+    /// # Availability
+    /// ❌ AMD ✅ Intel
     pub fn has_complex_indexing(&self) -> bool {
         get_bits(self.edx, 2, 2) == 1
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2557,7 +2557,7 @@ impl Debug for CacheParametersIter {
 /// Information about an individual cache in the hierarchy.
 ///
 /// # Platforms
-/// ❌ AMD ✅ Intel
+/// 🟡 AMD ✅ Intel
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct CacheParameter {
@@ -2599,6 +2599,9 @@ impl fmt::Display for CacheType {
 
 impl CacheParameter {
     /// Cache Type
+    ///
+    /// # Availability
+    /// ✅ AMD ✅ Intel
     pub fn cache_type(&self) -> CacheType {
         let typ = get_bits(self.eax, 0, 4) as u8;
         match typ {
@@ -2611,21 +2614,33 @@ impl CacheParameter {
     }
 
     /// Cache Level (starts at 1)
+    ///
+    /// # Availability
+    /// ✅ AMD ✅ Intel
     pub fn level(&self) -> u8 {
         get_bits(self.eax, 5, 7) as u8
     }
 
     /// Self Initializing cache level (does not need SW initialization).
+    ///
+    /// # Availability
+    /// ✅ AMD ✅ Intel
     pub fn is_self_initializing(&self) -> bool {
         get_bits(self.eax, 8, 8) == 1
     }
 
     /// Fully Associative cache
+    ///
+    /// # Availability
+    /// ✅ AMD ✅ Intel
     pub fn is_fully_associative(&self) -> bool {
         get_bits(self.eax, 9, 9) == 1
     }
 
     /// Maximum number of addressable IDs for logical processors sharing this cache
+    ///
+    /// # Availability
+    /// ✅ AMD ✅ Intel
     pub fn max_cores_for_cache(&self) -> usize {
         (get_bits(self.eax, 14, 25) + 1) as usize
     }
@@ -2639,21 +2654,33 @@ impl CacheParameter {
     }
 
     /// System Coherency Line Size (Bits 11-00)
+    ///
+    /// # Availability
+    /// ✅ AMD ✅ Intel
     pub fn coherency_line_size(&self) -> usize {
         (get_bits(self.ebx, 0, 11) + 1) as usize
     }
 
     /// Physical Line partitions (Bits 21-12)
+    ///
+    /// # Availability
+    /// ✅ AMD ✅ Intel
     pub fn physical_line_partitions(&self) -> usize {
         (get_bits(self.ebx, 12, 21) + 1) as usize
     }
 
     /// Ways of associativity (Bits 31-22)
+    ///
+    /// # Availability
+    /// ✅ AMD ✅ Intel
     pub fn associativity(&self) -> usize {
         (get_bits(self.ebx, 22, 31) + 1) as usize
     }
 
     /// Number of Sets (Bits 31-00)
+    ///
+    /// # Availability
+    /// ✅ AMD ✅ Intel
     pub fn sets(&self) -> usize {
         (self.ecx + 1) as usize
     }
@@ -2661,6 +2688,9 @@ impl CacheParameter {
     /// Write-Back Invalidate/Invalidate (Bit 0)
     /// False: WBINVD/INVD from threads sharing this cache acts upon lower level caches for threads sharing this cache.
     /// True: WBINVD/INVD is not guaranteed to act upon lower level caches of non-originating threads sharing this cache.
+    ///
+    /// # Availability
+    /// ✅ AMD ✅ Intel
     pub fn is_write_back_invalidate(&self) -> bool {
         get_bits(self.edx, 0, 0) == 1
     }
@@ -2668,6 +2698,9 @@ impl CacheParameter {
     /// Cache Inclusiveness (Bit 1)
     /// False: Cache is not inclusive of lower cache levels.
     /// True: Cache is inclusive of lower cache levels.
+    ///
+    /// # Availability
+    /// ✅ AMD ✅ Intel
     pub fn is_inclusive(&self) -> bool {
         get_bits(self.edx, 1, 1) == 1
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2670,10 +2670,10 @@ impl CacheParameter {
     }
 
     /// Complex Cache Indexing (Bit 2)
-    /// False: Direct mapped cache. (1-way)
+    /// False: Direct mapped cache.
     /// True: A complex function is used to index the cache, potentially using all address bits.
     pub fn has_complex_indexing(&self) -> bool {
-        get_bits(self.edx, 2, 2) == 1 || get_bits(self.ebx, 22, 31) != 0
+        get_bits(self.edx, 2, 2) == 1
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ impl CpuId {
         }
     }
 
-    /// Retrieve more elaborate information about caches (LEAF=0x04).
+    /// Retrieve more elaborate information about caches (LEAF=0x04 or 0x8000_001D).
     ///
     /// As opposed to [get_cache_info](CpuId::get_cache_info), this will tell us
     /// about associativity, set size, line size of each level in the cache


### PR DESCRIPTION
Related: #61

AMD CPU supports Leaf: `0x8000_001D` from Family 15h, same format as Intel Leaf: `0x4`.
<https://www.amd.com/system/files/TechDocs/42301_15h_Mod_00h-0Fh_BKDG.pdf>