### PR TITLE
 Implement AMD leaf 0x8000_001E (Processor Topology Information)

### DIFF
--- a/src/bin/cpuid.rs
+++ b/src/bin/cpuid.rs
@@ -1455,6 +1455,20 @@ fn markdown(_opts: Opts) {
         );
     }
 
+    if let Some(info) = cpuid.get_processor_topology_info() {
+        print_title(&skin, "Processor Topology Info (0x8000_001e):");
+        table2(
+            &skin,
+            &[
+                RowGen::tuple("x2APIC ID", info.x2apic_id()),
+                RowGen::tuple("Core ID", info.core_id()),
+                RowGen::tuple("Threads per core", info.threads_per_core()),
+                RowGen::tuple("Node ID", info.node_id()),
+                RowGen::tuple("Nodes per processor", info.nodes_per_processor()),
+            ],
+        );
+    }
+
     if let Some(info) = cpuid.get_memory_encryption_info() {
         print_title(&skin, "Memory Encryption Support (0x8000_001f):");
         table2(

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -1298,134 +1298,6 @@ bitflags! {
     }
 }
 
-/// Encrypted Memory Capabilities
-///
-/// # Platforms
-/// ✅ AMD ❌ Intel
-#[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-pub struct MemoryEncryptionInfo {
-    eax: MemoryEncryptionInfoEax,
-    ebx: u32,
-    ecx: u32,
-    edx: u32,
-}
-
-impl MemoryEncryptionInfo {
-    pub(crate) fn new(data: CpuIdResult) -> Self {
-        Self {
-            eax: MemoryEncryptionInfoEax::from_bits_truncate(data.eax),
-            ebx: data.ebx,
-            ecx: data.ecx,
-            edx: data.edx,
-        }
-    }
-
-    /// Secure Memory Encryption is supported if set.
-    pub fn has_sme(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::SME)
-    }
-
-    /// Secure Encrypted Virtualization is supported if set.
-    pub fn has_sev(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::SEV)
-    }
-
-    /// The Page Flush MSR is available if set.
-    pub fn has_page_flush_msr(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::PAGE_FLUSH_MSR)
-    }
-
-    /// SEV Encrypted State is supported if set.
-    pub fn has_sev_es(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::SEV_ES)
-    }
-
-    /// SEV Secure Nested Paging supported if set.
-    pub fn has_sev_snp(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::SEV_SNP)
-    }
-
-    /// VM Permission Levels supported if set.
-    pub fn has_vmpl(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::VMPL)
-    }
-
-    /// Hardware cache coherency across encryption domains enforced if set.
-    pub fn has_hw_enforced_cache_coh(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::HWENFCACHECOH)
-    }
-
-    /// SEV guest execution only allowed from a 64-bit host if set.
-    pub fn has_64bit_mode(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::HOST64)
-    }
-
-    /// Restricted Injection supported if set.
-    pub fn has_restricted_injection(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::RESTINJECT)
-    }
-
-    /// Alternate Injection supported if set.
-    pub fn has_alternate_injection(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::ALTINJECT)
-    }
-
-    /// Full debug state swap supported for SEV-ES guests.
-    pub fn has_debug_swap(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::DBGSWP)
-    }
-
-    /// Disallowing IBS use by the host supported if set.
-    pub fn has_prevent_host_ibs(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::PREVHOSTIBS)
-    }
-
-    /// Virtual Transparent Encryption supported if set.
-    pub fn has_vte(&self) -> bool {
-        self.eax.contains(MemoryEncryptionInfoEax::VTE)
-    }
-
-    /// C-bit location in page table entry
-    pub fn c_bit_position(&self) -> u8 {
-        get_bits(self.ebx, 0, 5) as u8
-    }
-
-    /// Physical Address bit reduction
-    pub fn physical_address_reduction(&self) -> u8 {
-        get_bits(self.ebx, 6, 11) as u8
-    }
-
-    /// Number of encrypted guests supported simultaneouslys
-    pub fn max_encrypted_guests(&self) -> u32 {
-        self.ecx
-    }
-
-    /// Minimum ASID value for an SEV enabled, SEV-ES disabled guest
-    pub fn min_sev_no_es_asid(&self) -> u32 {
-        self.edx
-    }
-}
-
-bitflags! {
-    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-    struct MemoryEncryptionInfoEax: u32 {
-        const SME = 1 << 0;
-        const SEV = 1 << 1;
-        const PAGE_FLUSH_MSR = 1 << 2;
-        const SEV_ES = 1 << 3;
-        const SEV_SNP = 1 << 4;
-        const VMPL = 1 << 5;
-        const HWENFCACHECOH = 1 << 10;
-        const HOST64 = 1 << 11;
-        const RESTINJECT = 1 << 12;
-        const ALTINJECT = 1 << 13;
-        const DBGSWP = 1 << 14;
-        const PREVHOSTIBS = 1 << 15;
-        const VTE = 1 << 16;
-    }
-}
-
 /// Information about the SVM features that the processory supports (LEAF=0x8000_000A).
 ///
 /// # Note
@@ -1695,5 +1567,133 @@ impl Debug for ProcessorTopologyInfo {
             .field("node_id", &self.node_id())
             .field("nodes_per_processor", &self.nodes_per_processor())
             .finish()
+    }
+}
+
+/// Encrypted Memory Capabilities (LEAF=0x8000_001F).
+///
+/// # Platforms
+/// ✅ AMD ❌ Intel
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct MemoryEncryptionInfo {
+    eax: MemoryEncryptionInfoEax,
+    ebx: u32,
+    ecx: u32,
+    edx: u32,
+}
+
+impl MemoryEncryptionInfo {
+    pub(crate) fn new(data: CpuIdResult) -> Self {
+        Self {
+            eax: MemoryEncryptionInfoEax::from_bits_truncate(data.eax),
+            ebx: data.ebx,
+            ecx: data.ecx,
+            edx: data.edx,
+        }
+    }
+
+    /// Secure Memory Encryption is supported if set.
+    pub fn has_sme(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::SME)
+    }
+
+    /// Secure Encrypted Virtualization is supported if set.
+    pub fn has_sev(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::SEV)
+    }
+
+    /// The Page Flush MSR is available if set.
+    pub fn has_page_flush_msr(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::PAGE_FLUSH_MSR)
+    }
+
+    /// SEV Encrypted State is supported if set.
+    pub fn has_sev_es(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::SEV_ES)
+    }
+
+    /// SEV Secure Nested Paging supported if set.
+    pub fn has_sev_snp(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::SEV_SNP)
+    }
+
+    /// VM Permission Levels supported if set.
+    pub fn has_vmpl(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::VMPL)
+    }
+
+    /// Hardware cache coherency across encryption domains enforced if set.
+    pub fn has_hw_enforced_cache_coh(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::HWENFCACHECOH)
+    }
+
+    /// SEV guest execution only allowed from a 64-bit host if set.
+    pub fn has_64bit_mode(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::HOST64)
+    }
+
+    /// Restricted Injection supported if set.
+    pub fn has_restricted_injection(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::RESTINJECT)
+    }
+
+    /// Alternate Injection supported if set.
+    pub fn has_alternate_injection(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::ALTINJECT)
+    }
+
+    /// Full debug state swap supported for SEV-ES guests.
+    pub fn has_debug_swap(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::DBGSWP)
+    }
+
+    /// Disallowing IBS use by the host supported if set.
+    pub fn has_prevent_host_ibs(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::PREVHOSTIBS)
+    }
+
+    /// Virtual Transparent Encryption supported if set.
+    pub fn has_vte(&self) -> bool {
+        self.eax.contains(MemoryEncryptionInfoEax::VTE)
+    }
+
+    /// C-bit location in page table entry
+    pub fn c_bit_position(&self) -> u8 {
+        get_bits(self.ebx, 0, 5) as u8
+    }
+
+    /// Physical Address bit reduction
+    pub fn physical_address_reduction(&self) -> u8 {
+        get_bits(self.ebx, 6, 11) as u8
+    }
+
+    /// Number of encrypted guests supported simultaneouslys
+    pub fn max_encrypted_guests(&self) -> u32 {
+        self.ecx
+    }
+
+    /// Minimum ASID value for an SEV enabled, SEV-ES disabled guest
+    pub fn min_sev_no_es_asid(&self) -> u32 {
+        self.edx
+    }
+}
+
+bitflags! {
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+    struct MemoryEncryptionInfoEax: u32 {
+        const SME = 1 << 0;
+        const SEV = 1 << 1;
+        const PAGE_FLUSH_MSR = 1 << 2;
+        const SEV_ES = 1 << 3;
+        const SEV_SNP = 1 << 4;
+        const VMPL = 1 << 5;
+        const HWENFCACHECOH = 1 << 10;
+        const HOST64 = 1 << 11;
+        const RESTINJECT = 1 << 12;
+        const ALTINJECT = 1 << 13;
+        const DBGSWP = 1 << 14;
+        const PREVHOSTIBS = 1 << 15;
+        const VTE = 1 << 16;
     }
 }

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -1635,3 +1635,65 @@ bitflags! {
         const FP256 = 1 << 2;
     }
 }
+
+/// Processor Topology Information (LEAF=0x8000_001E).
+///
+/// # Platforms
+/// ✅ AMD ❌ Intel
+#[derive(PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct ProcessorTopologyInfo {
+    eax: u32,
+    ebx: u32,
+    ecx: u32,
+    /// Reserved
+    _edx: u32,
+}
+
+impl ProcessorTopologyInfo {
+    pub(crate) fn new(data: CpuIdResult) -> Self {
+        Self {
+            eax: data.eax,
+            ebx: data.ebx,
+            ecx: data.ecx,
+            _edx: data.edx,
+        }
+    }
+
+    /// x2APIC ID
+    pub fn x2apic_id(&self) -> u32 {
+        self.eax
+    }
+
+    /// Core ID
+    pub fn core_id(&self) -> u8 {
+        get_bits(self.ebx, 0, 7) as u8
+    }
+
+    /// Threads per core
+    pub fn threads_per_core(&self) -> u8 {
+        get_bits(self.ebx, 8, 15) as u8 + 1
+    }
+
+    /// Node ID
+    pub fn node_id(&self) -> u8 {
+        get_bits(self.ecx, 0, 7) as u8
+    }
+
+    /// Nodes per processor
+    pub fn nodes_per_processor(&self) -> u8 {
+        get_bits(self.ecx, 8, 10) as u8 + 1
+    }
+}
+
+impl Debug for ProcessorTopologyInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProcessorTopologyInfo")
+            .field("x2apic_id", &self.x2apic_id())
+            .field("core_id", &self.core_id())
+            .field("threads_per_core", &self.threads_per_core())
+            .field("node_id", &self.node_id())
+            .field("nodes_per_processor", &self.nodes_per_processor())
+            .finish()
+    }
+}

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -1538,11 +1538,17 @@ impl ProcessorTopologyInfo {
     }
 
     /// Core ID
+    ///
+    /// # Note
+    /// `Core ID` means `Compute Unit ID` if AMD Family 15h-16h Processors.
     pub fn core_id(&self) -> u8 {
         get_bits(self.ebx, 0, 7) as u8
     }
 
     /// Threads per core
+    ///
+    /// # Note
+    /// `Threads per Core` means `Cores per Compute Unit` if AMD Family 15h-16h Processors.
     pub fn threads_per_core(&self) -> u8 {
         get_bits(self.ebx, 8, 15) as u8 + 1
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -893,7 +893,7 @@ impl CpuId {
     }
 
     /// This function provides information about the SVM features that the processory
-    /// supports.
+    /// supports. (LEAF=0x8000_000A)
     ///
     /// If SVM is not supported if [ExtendedProcessorFeatureIdentifiers::has_svm] is
     /// false, this function is reserved then.
@@ -906,20 +906,6 @@ impl CpuId {
             .map_or(false, |f| f.has_svm());
         if has_svm && self.leaf_is_supported(EAX_SVM_FEATURES) {
             Some(SvmFeatures::new(self.read.cpuid1(EAX_SVM_FEATURES)))
-        } else {
-            None
-        }
-    }
-
-    /// Informations about memory encryption support (LEAF=0x8000_001F)
-    ///
-    /// # Platforms
-    /// ✅ AMD ❌ Intel (reserved)
-    pub fn get_memory_encryption_info(&self) -> Option<MemoryEncryptionInfo> {
-        if self.leaf_is_supported(EAX_MEMORY_ENCRYPTION_INFO) {
-            Some(MemoryEncryptionInfo::new(
-                self.read.cpuid1(EAX_MEMORY_ENCRYPTION_INFO),
-            ))
         } else {
             None
         }
@@ -947,6 +933,20 @@ impl CpuId {
         if self.leaf_is_supported(EAX_PROCESSOR_TOPOLOGY_INFO) {
             Some(ProcessorTopologyInfo::new(
                 self.read.cpuid1(EAX_PROCESSOR_TOPOLOGY_INFO),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Informations about memory encryption support (LEAF=0x8000_001F)
+    ///
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved)
+    pub fn get_memory_encryption_info(&self) -> Option<MemoryEncryptionInfo> {
+        if self.leaf_is_supported(EAX_MEMORY_ENCRYPTION_INFO) {
+            Some(MemoryEncryptionInfo::new(
+                self.read.cpuid1(EAX_MEMORY_ENCRYPTION_INFO),
             ))
         } else {
             None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,6 +326,7 @@ const EAX_ADVANCED_POWER_MGMT_INFO: u32 = 0x8000_0007;
 const EAX_PROCESSOR_CAPACITY_INFO: u32 = 0x8000_0008;
 const EAX_PERFORMANCE_OPTIMIZATION_INFO: u32 = 0x8000_001A;
 const EAX_CACHE_PARAMETERS_AMD: u32 = 0x8000_001D;
+const EAX_PROCESSOR_TOPOLOGY_INFO: u32 = 0x8000_001E;
 const EAX_MEMORY_ENCRYPTION_INFO: u32 = 0x8000_001F;
 const EAX_SVM_FEATURES: u32 = 0x8000_000A;
 
@@ -923,6 +924,7 @@ impl CpuId {
             None
         }
     }
+
     /// Informations about performance optimization (LEAF=0x8000_001A)
     ///
     /// # Platforms
@@ -931,6 +933,20 @@ impl CpuId {
         if self.leaf_is_supported(EAX_PERFORMANCE_OPTIMIZATION_INFO) {
             Some(PerformanceOptimizationInfo::new(
                 self.read.cpuid1(EAX_PERFORMANCE_OPTIMIZATION_INFO),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Informations about processor topology (LEAF=0x8000_001E)
+    ///
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved)
+    pub fn get_processor_topology_info(&self) -> Option<ProcessorTopologyInfo> {
+        if self.leaf_is_supported(EAX_PROCESSOR_TOPOLOGY_INFO) {
+            Some(ProcessorTopologyInfo::new(
+                self.read.cpuid1(EAX_PROCESSOR_TOPOLOGY_INFO),
             ))
         } else {
             None

--- a/src/tests/ryzen_matisse.rs
+++ b/src/tests/ryzen_matisse.rs
@@ -1228,6 +1228,20 @@ fn performance_optimization_info() {
 }
 
 #[test]
+fn processor_topology_info() {
+    let cpuid = CpuId::with_cpuid_fn(cpuid_reader);
+    let e = cpuid
+        .get_processor_topology_info()
+        .expect("Leaf is supported");
+
+    assert!(e.x2apic_id() == 0);
+    assert!(e.core_id() == 0);
+    assert!(e.threads_per_core() == 2);
+    assert!(e.node_id() == 0);
+    assert!(e.nodes_per_processor() == 1);
+}
+
+#[test]
 fn remaining_unsupported_leafs() {
     let cpuid = CpuId::with_cpuid_fn(cpuid_reader);
 

--- a/src/tests/xeon_gold_6252.rs
+++ b/src/tests/xeon_gold_6252.rs
@@ -1198,4 +1198,7 @@ fn remaining_unsupported_leafs() {
     assert!(cpuid.get_deterministic_address_translation_info().is_none());
     assert!(cpuid.get_soc_vendor_info().is_none());
     assert!(cpuid.get_extended_topology_info_v2().is_none());
+    assert!(cpuid.get_performance_optimization_info().is_none());
+    assert!(cpuid.get_processor_topology_info().is_none());
+    assert!(cpuid.get_memory_encryption_info().is_none());
 }


### PR DESCRIPTION
Related: #62

It seems that the result of the comment part of the `ryzen_matisse` test file and the CPUID value are different.  
Do you want to leave it as is?

```
///   extended APIC ID = 10
///   Core Identifiers (0x8000001e/ebx):
///      core ID          = 0x5 (5)
///      threads per core = 0x2 (2)
///   Node Identifiers (0x8000001e/ecx):
///      node ID             = 0x0 (0)
///      nodes per processor = 0x1 (1)
```
```
    0x8000001e_00000000u64 => CpuIdResult { eax: 0x00000000, ebx: 0x00000100, ecx: 0x00000000, edx: 0x00000000 },
```