### PR TITLE
More granular display features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,12 @@ required-features = ["cli"]
 
 [features]
 std = []
-display = ["std", "termimad", "serde_json", "serialize"]
+display-raw = ["std"]
+display-markdown = ["std", "termimad"]
+display-json = ["std", "serde_json", "serialize"]
 serialize = ["serde", "serde_derive"]
 # This is not a library feature and should only be used to install the cpuid binary:
-cli = ["display", "clap"]
+cli = ["clap", "display-json", "display-markdown", "display-raw"]
 
 [dependencies]
 bitflags = "1.2"

--- a/src/display.rs
+++ b/src/display.rs
@@ -166,12 +166,12 @@ pub fn json(cpuid: crate::CpuId) {
 }
 
 #[cfg(feature = "display-markdown")]
-pub fn markdown(cpuid: CpuId) {
+pub fn markdown(cpuid: crate::CpuId) {
     use std::fmt::Display;
     use termimad::{minimad::TextTemplate, minimad::TextTemplateExpander, MadSkin};
 
     use crate::{
-        Associativity, CacheType, CpuId, CpuIdResult, DatType, ExtendedRegisterStateLocation,
+        Associativity, CacheType, CpuIdResult, DatType, ExtendedRegisterStateLocation,
         SgxSectionInfo, SoCVendorBrand, TopologyType,
     };
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -21,7 +21,7 @@ pub fn raw() {
 }
 
 #[cfg(feature = "display-json")]
-pub fn json(cpuid: CpuId) {
+pub fn json(cpuid: crate::CpuId) {
     if let Some(info) = cpuid.get_vendor_info() {
         println!("VendorInfo {}", serde_json::to_string(&info).unwrap());
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,10 +1,3 @@
-use std::fmt::Display;
-
-use crate::{
-    Associativity, CacheType, CpuId, CpuIdResult, DatType, ExtendedRegisterStateLocation,
-    SgxSectionInfo, SoCVendorBrand, TopologyType,
-};
-
 #[cfg(feature = "display-raw")]
 pub fn raw() {
     use crate::cpuid;
@@ -174,7 +167,13 @@ pub fn json(cpuid: CpuId) {
 
 #[cfg(feature = "display-markdown")]
 pub fn markdown(cpuid: CpuId) {
+    use std::fmt::Display;
     use termimad::{minimad::TextTemplate, minimad::TextTemplateExpander, MadSkin};
+
+    use crate::{
+        Associativity, CacheType, CpuId, CpuIdResult, DatType, ExtendedRegisterStateLocation,
+        SgxSectionInfo, SoCVendorBrand, TopologyType,
+    };
 
     fn string_to_static_str(s: String) -> &'static str {
         Box::leak(s.into_boxed_str())

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,13 +1,13 @@
 use std::fmt::Display;
 
 use crate::{
-    cpuid, Associativity, CacheType, CpuId, CpuIdResult, DatType, ExtendedRegisterStateLocation,
+    Associativity, CacheType, CpuId, CpuIdResult, DatType, ExtendedRegisterStateLocation,
     SgxSectionInfo, SoCVendorBrand, TopologyType,
 };
 
-use termimad::{minimad::TextTemplate, minimad::TextTemplateExpander, MadSkin};
-
+#[cfg(feature = "display-raw")]
 pub fn raw() {
+    use crate::cpuid;
     let _leafs_with_subleafs = &[0x04, 0x0d, 0x0f, 0x10, 0x12];
 
     let max_leafs = cpuid!(0x0).eax;
@@ -27,6 +27,7 @@ pub fn raw() {
     }
 }
 
+#[cfg(feature = "display-json")]
 pub fn json(cpuid: CpuId) {
     if let Some(info) = cpuid.get_vendor_info() {
         println!("VendorInfo {}", serde_json::to_string(&info).unwrap());
@@ -171,219 +172,226 @@ pub fn json(cpuid: CpuId) {
     }
 }
 
-fn string_to_static_str(s: String) -> &'static str {
-    Box::leak(s.into_boxed_str())
-}
+#[cfg(feature = "display-markdown")]
+pub fn markdown(cpuid: CpuId) {
+    use termimad::{minimad::TextTemplate, minimad::TextTemplateExpander, MadSkin};
 
-fn table2(skin: &MadSkin, attrs: &[(&'static str, String)]) {
-    let table_template = TextTemplate::from(
-        r#"
+    fn string_to_static_str(s: String) -> &'static str {
+        Box::leak(s.into_boxed_str())
+    }
+
+    fn table2(skin: &MadSkin, attrs: &[(&'static str, String)]) {
+        let table_template = TextTemplate::from(
+            r#"
 |-:|-:|
 ${feature-rows
 |**${attr-name}**|${attr-avail}|
 }
 |-|-|
     "#,
-    );
+        );
 
-    fn make_table_display<'a, 'b, D: Display>(
-        text_template: &'a TextTemplate<'b>,
-        attrs: &[(&'b str, D)],
-    ) -> TextTemplateExpander<'a, 'b> {
-        let mut expander = text_template.expander();
+        fn make_table_display<'a, 'b, D: Display>(
+            text_template: &'a TextTemplate<'b>,
+            attrs: &[(&'b str, D)],
+        ) -> TextTemplateExpander<'a, 'b> {
+            let mut expander = text_template.expander();
 
-        for (attr, desc) in attrs {
-            let sdesc = string_to_static_str(format!("{}", desc));
+            for (attr, desc) in attrs {
+                let sdesc = string_to_static_str(format!("{}", desc));
+                expander
+                    .sub("feature-rows")
+                    .set("attr-name", attr)
+                    .set("attr-avail", sdesc);
+            }
+
             expander
-                .sub("feature-rows")
-                .set("attr-name", attr)
-                .set("attr-avail", sdesc);
         }
 
-        expander
+        let table = make_table_display(&table_template, &attrs);
+        skin.print_expander(table);
     }
 
-    let table = make_table_display(&table_template, &attrs);
-    skin.print_expander(table);
-}
-
-fn table3(skin: &MadSkin, attrs: &[(&'static str, &'static str, String)]) {
-    let table_template3 = TextTemplate::from(
-        r#"
+    fn table3(skin: &MadSkin, attrs: &[(&'static str, &'static str, String)]) {
+        let table_template3 = TextTemplate::from(
+            r#"
 |:-|-:|-:|
 ${feature-rows
 |**${category-name}**|**${attr-name}**|${attr-avail}|
 }
 |-|-|
     "#,
-    );
+        );
 
-    fn make_table_display3<'a, 'b, D: Display>(
-        text_template: &'a TextTemplate<'b>,
-        attrs: &[(&'b str, &'b str, D)],
-    ) -> TextTemplateExpander<'a, 'b> {
-        let mut expander = text_template.expander();
+        fn make_table_display3<'a, 'b, D: Display>(
+            text_template: &'a TextTemplate<'b>,
+            attrs: &[(&'b str, &'b str, D)],
+        ) -> TextTemplateExpander<'a, 'b> {
+            let mut expander = text_template.expander();
 
-        for (cat, attr, desc) in attrs {
-            let sdesc = string_to_static_str(format!("{}", desc));
+            for (cat, attr, desc) in attrs {
+                let sdesc = string_to_static_str(format!("{}", desc));
+                expander
+                    .sub("feature-rows")
+                    .set("category-name", cat)
+                    .set("attr-name", attr)
+                    .set("attr-avail", sdesc);
+            }
+
             expander
-                .sub("feature-rows")
-                .set("category-name", cat)
-                .set("attr-name", attr)
-                .set("attr-avail", sdesc);
         }
 
-        expander
+        let table = make_table_display3(&table_template3, &attrs);
+        skin.print_expander(table);
     }
 
-    let table = make_table_display3(&table_template3, &attrs);
-    skin.print_expander(table);
-}
-
-fn print_title_line(skin: &MadSkin, title: &str, attr: Option<&str>) {
-    if let Some(opt) = attr {
-        skin.print_text(format!("## {} = \"{}\"\n", title, opt).as_str());
-    } else {
-        skin.print_text(format!("## {}\n", title).as_str());
-    }
-}
-
-fn print_title_attr(skin: &MadSkin, title: &str, attr: &str) {
-    print_title_line(skin, title, Some(attr));
-}
-
-fn print_title(skin: &MadSkin, title: &str) {
-    print_title_line(skin, title, None)
-}
-
-fn print_subtitle(skin: &MadSkin, title: &str) {
-    skin.print_text(format!("### {}\n", title).as_str());
-}
-
-fn print_attr<T: Display, A: Display>(skin: &MadSkin, name: T, attr: A) {
-    skin.print_text(format!("{} = {}", name, attr).as_str());
-}
-
-fn print_cpuid_result<T: Display>(skin: &MadSkin, name: T, attr: CpuIdResult) {
-    skin.print_text(
-        format!(
-            "{}: eax = {:#x} ebx = {:#x} ecx = {:#x} edx = {:#x}",
-            name, attr.eax, attr.ebx, attr.ecx, attr.edx,
-        )
-        .as_str(),
-    );
-}
-
-fn bool_repr(x: bool) -> String {
-    if x {
-        "✅".to_string()
-    } else {
-        "❌".to_string()
-    }
-}
-
-trait RowGen {
-    fn fmt(attr: &Self) -> String;
-
-    fn tuple(t: &'static str, attr: Self) -> (&'static str, String)
-    where
-        Self: Sized,
-    {
-        (t, RowGen::fmt(&attr))
+    fn print_title_line(skin: &MadSkin, title: &str, attr: Option<&str>) {
+        if let Some(opt) = attr {
+            skin.print_text(format!("## {} = \"{}\"\n", title, opt).as_str());
+        } else {
+            skin.print_text(format!("## {}\n", title).as_str());
+        }
     }
 
-    fn triple(c: &'static str, t: &'static str, attr: Self) -> (&'static str, &'static str, String)
-    where
-        Self: Sized,
-    {
-        (c, t, RowGen::fmt(&attr))
+    fn print_title_attr(skin: &MadSkin, title: &str, attr: &str) {
+        print_title_line(skin, title, Some(attr));
     }
-}
 
-impl RowGen for bool {
-    fn fmt(attr: &Self) -> String {
-        bool_repr(*attr)
+    fn print_title(skin: &MadSkin, title: &str) {
+        print_title_line(skin, title, None)
     }
-}
 
-impl RowGen for u64 {
-    fn fmt(attr: &Self) -> String {
-        format!("{}", attr)
+    fn print_subtitle(skin: &MadSkin, title: &str) {
+        skin.print_text(format!("### {}\n", title).as_str());
     }
-}
 
-impl RowGen for usize {
-    fn fmt(attr: &Self) -> String {
-        format!("{}", attr)
+    fn print_attr<T: Display, A: Display>(skin: &MadSkin, name: T, attr: A) {
+        skin.print_text(format!("{} = {}", name, attr).as_str());
     }
-}
 
-impl RowGen for u32 {
-    fn fmt(attr: &Self) -> String {
-        format!("{}", attr)
+    fn print_cpuid_result<T: Display>(skin: &MadSkin, name: T, attr: CpuIdResult) {
+        skin.print_text(
+            format!(
+                "{}: eax = {:#x} ebx = {:#x} ecx = {:#x} edx = {:#x}",
+                name, attr.eax, attr.ebx, attr.ecx, attr.edx,
+            )
+            .as_str(),
+        );
     }
-}
 
-impl RowGen for u16 {
-    fn fmt(attr: &Self) -> String {
-        format!("{}", attr)
+    fn bool_repr(x: bool) -> String {
+        if x {
+            "✅".to_string()
+        } else {
+            "❌".to_string()
+        }
     }
-}
 
-impl RowGen for u8 {
-    fn fmt(attr: &Self) -> String {
-        format!("{}", attr)
+    trait RowGen {
+        fn fmt(attr: &Self) -> String;
+
+        fn tuple(t: &'static str, attr: Self) -> (&'static str, String)
+        where
+            Self: Sized,
+        {
+            (t, RowGen::fmt(&attr))
+        }
+
+        fn triple(
+            c: &'static str,
+            t: &'static str,
+            attr: Self,
+        ) -> (&'static str, &'static str, String)
+        where
+            Self: Sized,
+        {
+            (c, t, RowGen::fmt(&attr))
+        }
     }
-}
 
-impl RowGen for String {
-    fn fmt(attr: &Self) -> String {
-        format!("{}", attr)
+    impl RowGen for bool {
+        fn fmt(attr: &Self) -> String {
+            bool_repr(*attr)
+        }
     }
-}
 
-impl RowGen for Associativity {
-    fn fmt(attr: &Self) -> String {
-        format!("{}", attr)
+    impl RowGen for u64 {
+        fn fmt(attr: &Self) -> String {
+            format!("{}", attr)
+        }
     }
-}
 
-impl RowGen for CacheType {
-    fn fmt(attr: &Self) -> String {
-        format!("{}", attr)
+    impl RowGen for usize {
+        fn fmt(attr: &Self) -> String {
+            format!("{}", attr)
+        }
     }
-}
 
-impl RowGen for TopologyType {
-    fn fmt(attr: &Self) -> String {
-        format!("{}", attr)
+    impl RowGen for u32 {
+        fn fmt(attr: &Self) -> String {
+            format!("{}", attr)
+        }
     }
-}
 
-impl RowGen for ExtendedRegisterStateLocation {
-    fn fmt(attr: &Self) -> String {
-        format!("{}", attr)
+    impl RowGen for u16 {
+        fn fmt(attr: &Self) -> String {
+            format!("{}", attr)
+        }
     }
-}
 
-impl RowGen for DatType {
-    fn fmt(attr: &Self) -> String {
-        format!("{}", attr)
+    impl RowGen for u8 {
+        fn fmt(attr: &Self) -> String {
+            format!("{}", attr)
+        }
     }
-}
 
-impl RowGen for Option<SoCVendorBrand> {
-    fn fmt(attr: &Self) -> String {
-        format!(
-            "{}",
-            attr.as_ref()
-                .map(|v| v.as_str().to_string())
-                .unwrap_or(String::from(""))
-        )
+    impl RowGen for String {
+        fn fmt(attr: &Self) -> String {
+            format!("{}", attr)
+        }
     }
-}
 
-pub fn markdown(cpuid: CpuId) {
+    impl RowGen for Associativity {
+        fn fmt(attr: &Self) -> String {
+            format!("{}", attr)
+        }
+    }
+
+    impl RowGen for CacheType {
+        fn fmt(attr: &Self) -> String {
+            format!("{}", attr)
+        }
+    }
+
+    impl RowGen for TopologyType {
+        fn fmt(attr: &Self) -> String {
+            format!("{}", attr)
+        }
+    }
+
+    impl RowGen for ExtendedRegisterStateLocation {
+        fn fmt(attr: &Self) -> String {
+            format!("{}", attr)
+        }
+    }
+
+    impl RowGen for DatType {
+        fn fmt(attr: &Self) -> String {
+            format!("{}", attr)
+        }
+    }
+
+    impl RowGen for Option<SoCVendorBrand> {
+        fn fmt(attr: &Self) -> String {
+            format!(
+                "{}",
+                attr.as_ref()
+                    .map(|v| v.as_str().to_string())
+                    .unwrap_or(String::from(""))
+            )
+        }
+    }
+
     let skin = MadSkin::default();
     skin.print_text("# CpuId\n");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,11 @@
 #[macro_use]
 extern crate std;
 
-#[cfg(feature = "display")]
+#[cfg(any(
+    feature = "display-raw",
+    feature = "display-json",
+    feature = "display-markdown"
+))]
 pub mod display;
 mod extended;
 #[cfg(test)]


### PR DESCRIPTION
Thanks for merging in #137!

While trying to integrate it, I realized that it wasn't _quite_ fine-grained enough:
- We care about the "print as markdown" functionality, but not about the raw or JSON printing
- I'm building on an AArch64 machine, **not** x86
- The `display` feature includes `fn raw(...)` and `fn json(...)`, which both require an x86 CPU on the machine building the crate (the former because it calls `cpuid!()` directly; the latter because of how serialization is implemented)

This PR splits `display` into three features: `display-raw`, `display-json` and `display-markdown`, whose behavior is exactly what you'd expect 😄 

This allows me to build with just `display-markdown`, which compiles fine on an AArch64 machine.

Codewise, there are no logical changes, but I ended up moving the markdown helper functions into `fn markdown` itself, to avoid having a ton of conditional compilation directives.