### PR TITLE
update `bitflags` dependency to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serialize = ["serde", "serde_derive"]
 cli = ["display", "clap"]
 
 [dependencies]
-bitflags = "1.2"
+bitflags = "2.0"
 serde = {version = "1.0", default-features = false, optional = true}
 serde_derive = {version = "1.0", optional = true}
 serde_json = {version = "1.0", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,15 +26,15 @@ serialize = ["serde", "serde_derive"]
 cli = ["display", "clap"]
 
 [dependencies]
-bitflags = "2.0"
-serde = {version = "1.0", default-features = false, optional = true}
-serde_derive = {version = "1.0", optional = true}
-serde_json = {version = "1.0", optional = true}
-termimad = {version = "0.21", optional = true}
-clap = {version = "3.1.6", features = ["derive"], optional = true}
+bitflags = { version = "2.0", features = ["serde"] }
+serde = { version = "1.0", default-features = false, optional = true }
+serde_derive = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }
+termimad = { version = "0.21", optional = true }
+clap = { version = "3.1.6", features = ["derive"], optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 core_affinity = "0.8.0"
-libc = {version = "0.2", default-features = false}
-phf = {version = "0.11", features = ["macros"]}
+libc = { version = "0.2", default-features = false }
+phf = { version = "0.11", features = ["macros"] }
 rustversion = "1.0"

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -385,6 +385,8 @@ impl Debug for ExtendedProcessorFeatureIdentifiers {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct ExtendedFunctionInfoEcx: u32 {
         const LAHF_SAHF = 1 << 0;
@@ -416,6 +418,8 @@ bitflags! {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct ExtendedFunctionInfoEdx: u32 {
         const SYSCALL_SYSRET = 1 << 11;
@@ -1010,6 +1014,8 @@ impl ApmInfo {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct ApmInfoEdx: u32 {
         const TS = 1 << 0;
@@ -1028,6 +1034,8 @@ bitflags! {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct RasCapabilities: u32 {
         const MCAOVFLRECOV = 1 << 0;
@@ -1283,6 +1291,8 @@ impl Debug for ProcessorCapacityAndFeatureInfo {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct ProcessorCapacityAndFeatureEbx: u32 {
         const CLZERO = 1 << 0;
@@ -1433,6 +1443,8 @@ impl SvmFeatures {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct SvmFeaturesEdx: u32 {
         const NP = 1 << 0;
@@ -1570,6 +1582,8 @@ impl PerformanceOptimizationInfo {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct PerformanceOptimizationInfoEax: u32 {
         const FP128 = 1 << 0;
@@ -1756,6 +1770,8 @@ impl MemoryEncryptionInfo {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct MemoryEncryptionInfoEax: u32 {
         const SME = 1 << 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,9 +405,9 @@ impl CpuId {
                 vendor: self.vendor,
                 eax: res.eax,
                 ebx: res.ebx,
-                edx_ecx: FeatureInfoFlags {
-                    bits: (((res.edx as u64) << 32) | (res.ecx as u64)),
-                },
+                edx_ecx: FeatureInfoFlags::from_bits_truncate(
+                    ((res.edx as u64) << 32) | (res.ecx as u64),
+                ),
             })
         } else {
             None
@@ -504,9 +504,9 @@ impl CpuId {
         if self.leaf_is_supported(EAX_THERMAL_POWER_INFO) {
             let res = self.read.cpuid1(EAX_THERMAL_POWER_INFO);
             Some(ThermalPowerInfo {
-                eax: ThermalPowerFeaturesEax { bits: res.eax },
+                eax: ThermalPowerFeaturesEax::from_bits_truncate(res.eax),
                 ebx: res.ebx,
-                ecx: ThermalPowerFeaturesEcx { bits: res.ecx },
+                ecx: ThermalPowerFeaturesEcx::from_bits_truncate(res.ecx),
                 _edx: res.edx,
             })
         } else {
@@ -523,8 +523,8 @@ impl CpuId {
             let res = self.read.cpuid1(EAX_STRUCTURED_EXTENDED_FEATURE_INFO);
             Some(ExtendedFeatures {
                 _eax: res.eax,
-                ebx: ExtendedFeaturesEbx { bits: res.ebx },
-                ecx: ExtendedFeaturesEcx { bits: res.ecx },
+                ebx: ExtendedFeaturesEbx::from_bits_truncate(res.ebx),
+                ecx: ExtendedFeaturesEcx::from_bits_truncate(res.ecx),
                 _edx: res.edx,
             })
         } else {
@@ -554,7 +554,7 @@ impl CpuId {
             let res = self.read.cpuid1(EAX_PERFORMANCE_MONITOR_INFO);
             Some(PerformanceMonitoringInfo {
                 eax: res.eax,
-                ebx: PerformanceMonitoringFeaturesEbx { bits: res.ebx },
+                ebx: PerformanceMonitoringFeaturesEbx::from_bits_truncate(res.ebx),
                 _ecx: res.ecx,
                 edx: res.edx,
             })
@@ -609,13 +609,13 @@ impl CpuId {
             let res1 = self.read.cpuid2(EAX_EXTENDED_STATE_INFO, 1);
             Some(ExtendedStateInfo {
                 read: self.read,
-                eax: ExtendedStateInfoXCR0Flags { bits: res.eax },
+                eax: ExtendedStateInfoXCR0Flags::from_bits_truncate(res.eax),
                 ebx: res.ebx,
                 ecx: res.ecx,
                 _edx: res.edx,
                 eax1: res1.eax,
                 ebx1: res1.ebx,
-                ecx1: ExtendedStateInfoXSSFlags { bits: res1.ecx },
+                ecx1: ExtendedStateInfoXSSFlags::from_bits_truncate(res1.ecx),
                 _edx1: res1.edx,
             })
         } else {
@@ -2442,6 +2442,8 @@ impl Debug for FeatureInfo {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct FeatureInfoFlags: u64 {
 
@@ -3704,6 +3706,8 @@ impl Debug for ExtendedFeatures {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct ExtendedFeaturesEbx: u32 {
         /// FSGSBASE. Supports RDFSBASE/RDGSBASE/WRFSBASE/WRGSBASE if 1. (Bit 00)
@@ -3773,6 +3777,8 @@ bitflags! {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct ExtendedFeaturesEcx: u32 {
         /// Bit 0: Prefetch WT1. (Intel® Xeon Phi™ only).
@@ -3967,6 +3973,8 @@ impl Debug for PerformanceMonitoringInfo {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct PerformanceMonitoringFeaturesEbx: u32 {
         /// Core cycle event not available if 1. (Bit 0)
@@ -4128,6 +4136,8 @@ impl Debug for ExtendedTopologyIter {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct ExtendedStateInfoXCR0Flags: u32 {
         /// legacy x87 (Bit 00).
@@ -4163,6 +4173,8 @@ bitflags! {
 }
 
 bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     struct ExtendedStateInfoXSSFlags: u32 {
         /// IA32_XSS PT (Trace Packet) State (Bit 08).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4169,6 +4169,12 @@ bitflags! {
 
         /// IA32_XSS HDC State (Bit 13).
         const IA32_XSS_HDC = 1 << 13;
+
+        /// AMX TILECFG state (Bit 17)
+        const AMX_TILECFG = 1 << 17;
+
+        /// AMX TILEDATA state (Bit 17)
+        const AMX_TILEDATA = 1 << 18;
     }
 }
 
@@ -4180,8 +4186,26 @@ bitflags! {
         /// IA32_XSS PT (Trace Packet) State (Bit 08).
         const PT = 1 << 8;
 
+        /// IA32_XSS PASID state (Bit 10)
+        const PASID = 1 << 10;
+
+        /// IA32_XSS CET user state (Bit 11)
+        const CET_USER = 1 << 11;
+
+        /// IA32_XSS CET supervisor state (Bit 12)
+        const CET_SUPERVISOR = 1 << 12;
+
         /// IA32_XSS HDC State (Bit 13).
         const HDC = 1 << 13;
+
+        /// IA32_XSS UINTR state (Bit 14)
+        const UINTR = 1 << 14;
+
+        /// IA32_XSS LBR state (Bit 15)
+        const LBR = 1 << 15;
+
+        /// IA32_XSS HWP state (Bit 16)
+        const HWP = 1 << 16;
     }
 }
 

--- a/src/tests/i5_3337u.rs
+++ b/src/tests/i5_3337u.rs
@@ -16,9 +16,7 @@ fn feature_info() {
         vendor: Vendor::Intel,
         eax: 198313,
         ebx: 34605056,
-        edx_ecx: FeatureInfoFlags {
-            bits: 2109399999 | 3219913727 << 32,
-        },
+        edx_ecx: FeatureInfoFlags::from_bits_truncate(2109399999 | 3219913727 << 32),
     };
 
     assert!(finfo.base_model_id() == 10);
@@ -177,9 +175,9 @@ fn monitor_mwait_features() {
 #[test]
 fn thermal_power_features() {
     let tpfeatures = ThermalPowerInfo {
-        eax: ThermalPowerFeaturesEax { bits: 119 },
+        eax: ThermalPowerFeaturesEax::from_bits_truncate(119),
         ebx: 2,
-        ecx: ThermalPowerFeaturesEcx { bits: 9 },
+        ecx: ThermalPowerFeaturesEcx::from_bits_truncate(9),
         _edx: 0,
     };
 
@@ -239,8 +237,8 @@ fn thermal_power_features() {
 fn extended_features() {
     let tpfeatures = ExtendedFeatures {
         _eax: 0,
-        ebx: ExtendedFeaturesEbx { bits: 641 },
-        ecx: ExtendedFeaturesEcx { bits: 0 },
+        ebx: ExtendedFeaturesEbx::from_bits_truncate(641),
+        ecx: ExtendedFeaturesEcx::from_bits_truncate(0),
         _edx: 0,
     };
     assert!(tpfeatures._eax == 0);
@@ -274,7 +272,7 @@ fn extended_features() {
             | ExtendedFeaturesEbx::SMAP
             | ExtendedFeaturesEbx::CLFLUSHOPT
             | ExtendedFeaturesEbx::PROCESSOR_TRACE,
-        ecx: ExtendedFeaturesEcx { bits: 0 },
+        ecx: ExtendedFeaturesEcx::from_bits_truncate(0),
         _edx: 201326592,
     };
 
@@ -305,7 +303,7 @@ fn direct_cache_access_info() {
 fn performance_monitoring_info() {
     let pm = PerformanceMonitoringInfo {
         eax: 120587267,
-        ebx: PerformanceMonitoringFeaturesEbx { bits: 0 },
+        ebx: PerformanceMonitoringFeaturesEbx::from_bits_truncate(0),
         _ecx: 0,
         edx: 1539,
     };
@@ -402,13 +400,13 @@ fn extended_topology_info_v2() {
 fn extended_state_info() {
     let es = ExtendedStateInfo {
         read: Default::default(),
-        eax: ExtendedStateInfoXCR0Flags { bits: 7 },
+        eax: ExtendedStateInfoXCR0Flags::from_bits_truncate(7),
         ebx: 832,
         ecx: 832,
         _edx: 0,
         eax1: 1,
         ebx1: 0,
-        ecx1: ExtendedStateInfoXSSFlags { bits: 0 },
+        ecx1: ExtendedStateInfoXSSFlags::from_bits_truncate(0),
         _edx1: 0,
     };
 
@@ -588,13 +586,13 @@ fn extended_state_info3() {
 fn extended_state_info2() {
     let es = ExtendedStateInfo {
         read: Default::default(),
-        eax: ExtendedStateInfoXCR0Flags { bits: 31 },
+        eax: ExtendedStateInfoXCR0Flags::from_bits_truncate(31),
         ebx: 1088,
         ecx: 1088,
         _edx: 0,
         eax1: 15,
         ebx1: 960,
-        ecx1: ExtendedStateInfoXSSFlags { bits: 256 },
+        ecx1: ExtendedStateInfoXSSFlags::from_bits_truncate(256),
         _edx1: 0,
     };
 


### PR DESCRIPTION
As title says, simply updates the bitflags dependency to 2.0, and fixes up the code for any of the API changes from `1.2 -> 2.0`.

Namely, bitflags structs no longer implicitly define the following attributes:
```rust
#[repr(transparent)]
#[derive(Debug, Clone, Copy, PartialEq, Eq)]
```

These are re-implemented manually to reflect the proper derivations for the various bitflags types in the crate.

Additionally, many of the direct bitflags type constructors were broken:
```rust
let example = ExampleBitflags { bits: 0xdeadbeef };
// ... has been updated to ...
let example = ExampleBitflags::from_bits_truncate(0xdeadbeef);
```

While this is an effective behaviour change, the old behaviour *can* be retained via `::from_bits_retain`; however, this would only need to be used in cases where we fail to implement all of the bits of a specific CPUID bitflag (so, shouldn't be a concern with proper code coverage).