### PR TITLE
Restore CpuId's Debug implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ name = "cpuid"
 path = "src/bin/cpuid.rs"
 required-features = ["cli"]
 
+[[example]]
+name = "serialize_deserialize"
+path = "examples/serialize_deserialize.rs"
+required-features = ["serde_json"]
+
 [features]
 std = []
 display = ["std", "termimad", "serde_json", "serialize"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -964,7 +964,7 @@ impl<R: CpuIdReader> CpuId<R> {
     }
 }
 
-impl<R: CpuIdReader + Debug> Debug for CpuId<R> {
+impl<R: CpuIdReader> Debug for CpuId<R> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("CpuId")
             .field("vendor", &self.vendor)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,8 +9,7 @@ use crate::*;
 
 #[test]
 fn cpuid_impls_debug() {
-    fn debug_required<T: Debug>(t: T) {
-    }
+    fn debug_required<T: Debug>(t: T) {}
 
     debug_required(CpuId::new());
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4,3 +4,13 @@ mod i5_3337u;
 mod i7_12700k;
 mod ryzen_matisse;
 mod xeon_gold_6252;
+
+use crate::*;
+
+#[test]
+fn cpuid_impls_debug() {
+    fn debug_required<T: Debug>(t: T) {
+    }
+
+    debug_required(CpuId::new());
+}


### PR DESCRIPTION
This is a regression from 10.7.0. There's no need for CpuIdReader to support Debug, so drop it.