### PR TITLE
Add categories field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/gz/rust-cpuid"
 repository = "https://github.com/gz/rust-cpuid"
 
 keywords = ["cpuid", "x86", "amd64", "os", "libcore"]
+categories = ["no-std", "no-std::no-alloc"]
 license = "MIT"
 readme = "README.md"
 


### PR DESCRIPTION
Added [`categories`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-categories-field) field to indicate `#![no_std]` compatiblity in `Cargo.toml`. This change makes `raw-cpuid` visible to category-specific pages ([`no-std`](https://crates.io/categories/no-std) and [`no-std::no-alloc`](https://crates.io/categories/no-std::no-alloc)).