### PR TITLE
Implement Missing Extended Features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ serde_json = { version = "1.0", optional = true }
 termimad = { version = "0.25", optional = true }
 clap = { version = "4.2", features = ["derive"], optional = true }
 
-# [target.'cfg(unix)'.dev-dependencies]
 [dev-dependencies]
 core_affinity = "0.8.0"
 libc = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ serde_json = { version = "1.0", optional = true }
 termimad = { version = "0.25", optional = true }
 clap = { version = "4.2", features = ["derive"], optional = true }
 
-[target.'cfg(unix)'.dev-dependencies]
+# [target.'cfg(unix)'.dev-dependencies]
+[dev-dependencies]
 core_affinity = "0.8.0"
 libc = { version = "0.2", default-features = false }
 phf = { version = "0.11", features = ["macros"] }

--- a/src/display.rs
+++ b/src/display.rs
@@ -528,6 +528,12 @@ pub fn markdown<R: crate::CpuIdReader>(cpuid: crate::CpuId<R>) {
                     "AVX512F: AVX-512 foundation instructions",
                     info.has_avx512f(),
                 ),
+                RowGen::tuple("AVX512-4NNIW: 4NNIW instructions", info.has_avx512_4nniw()),
+                RowGen::tuple(
+                    "AVX512-4FMAPS: 4FMAPS instructions",
+                    info.has_avx512_4fmaps(),
+                ),
+                RowGen::tuple("AMX_BF16: AMX_BF16 instructions", info.has_amx_bf16()),
                 RowGen::tuple(
                     "AVX512DQ: double & quadword instructions",
                     info.has_avx512dq(),

--- a/src/display.rs
+++ b/src/display.rs
@@ -528,12 +528,6 @@ pub fn markdown<R: crate::CpuIdReader>(cpuid: crate::CpuId<R>) {
                     "AVX512F: AVX-512 foundation instructions",
                     info.has_avx512f(),
                 ),
-                RowGen::tuple("AVX512-4NNIW: 4NNIW instructions", info.has_avx512_4vnniw()),
-                RowGen::tuple(
-                    "AVX512-4FMAPS: 4FMAPS instructions",
-                    info.has_avx512_4fmaps(),
-                ),
-                RowGen::tuple("AMX_BF16: AMX_BF16 instructions", info.has_amx_bf16()),
                 RowGen::tuple(
                     "AVX512DQ: double & quadword instructions",
                     info.has_avx512dq(),

--- a/src/display.rs
+++ b/src/display.rs
@@ -528,6 +528,25 @@ pub fn markdown<R: crate::CpuIdReader>(cpuid: crate::CpuId<R>) {
                     "AVX512F: AVX-512 foundation instructions",
                     info.has_avx512f(),
                 ),
+                RowGen::tuple("AVX512-4NNIW: 4NNIW instructions", info.has_avx512_4vnniw()),
+                RowGen::tuple(
+                    "AVX512-4FMAPS: 4FMAPS instructions",
+                    info.has_avx512_4fmaps(),
+                ),
+                RowGen::tuple(
+                    "AVX512-VP2INTERSECT: VP2INTERSECT instructions",
+                    info.has_avx512_vp2intersect(),
+                ),
+                RowGen::tuple("AMX_BF16: AMX_BF16 instructions", info.has_amx_bf16()),
+                RowGen::tuple(
+                    "AVX512_FP16: AVX512_FP16 instructions",
+                    info.has_avx512_fp16(),
+                ),
+                RowGen::tuple("AMX_TILE: Tile Architecture support", info.has_amx_tile()),
+                RowGen::tuple(
+                    "AMX_INT8: Tile Computational Operation on 8-bit integers",
+                    info.has_amx_tile(),
+                ),
                 RowGen::tuple(
                     "AVX512DQ: double & quadword instructions",
                     info.has_avx512dq(),

--- a/src/display.rs
+++ b/src/display.rs
@@ -528,7 +528,7 @@ pub fn markdown<R: crate::CpuIdReader>(cpuid: crate::CpuId<R>) {
                     "AVX512F: AVX-512 foundation instructions",
                     info.has_avx512f(),
                 ),
-                RowGen::tuple("AVX512-4NNIW: 4NNIW instructions", info.has_avx512_4nniw()),
+                RowGen::tuple("AVX512-4NNIW: 4NNIW instructions", info.has_avx512_4vnniw()),
                 RowGen::tuple(
                     "AVX512-4FMAPS: 4FMAPS instructions",
                     info.has_avx512_4fmaps(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3672,12 +3672,12 @@ impl ExtendedFeatures {
         get_bits(self.ecx.bits(), 17, 21) as u8
     }
 
-    /// Supports AVX512_4NNIW.
+    /// Supports AVX512_4VNNIW.
     ///
     /// # Platforms
     /// ❌ AMD (reserved) ✅ Intel
     #[inline]
-    pub const fn has_avx512_4nniw(&self) -> bool {
+    pub const fn has_avx512_4vnniw(&self) -> bool {
         self.edx.contains(ExtendedFeaturesEdx::AVX512_4VNNIW)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3858,7 +3858,7 @@ bitflags! {
         const AVX512_FP16 = 1 << 23;
         /// Bit 24: AMX-TILE. If 1, the processor supports tile architecture
         const AMX_TILE = 1 << 24;
-        /// Bit 24: AMX-INT8. If 1, the processor supports tile computational operations on 8-bit integers.
+        /// Bit 25: AMX-INT8. If 1, the processor supports tile computational operations on 8-bit integers.
         const AMX_INT8 = 1 << 25;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3690,6 +3690,15 @@ impl ExtendedFeatures {
         self.edx.contains(ExtendedFeaturesEdx::AVX512_4FMAPS)
     }
 
+    /// Supports AVX512_VP2INTERSECT.
+    ///
+    /// # Platforms
+    /// ❌ AMD (reserved) ✅ Intel
+    #[inline]
+    pub const fn has_avx512_vp2intersect(&self) -> bool {
+        self.edx.contains(ExtendedFeaturesEdx::AVX512_VP2INTERSECT)
+    }
+
     /// Supports AMX_BF16.
     ///
     /// # Platforms
@@ -3699,13 +3708,31 @@ impl ExtendedFeatures {
         self.edx.contains(ExtendedFeaturesEdx::AMX_BF16)
     }
 
-    /// Supports AVX_FP16.
+    /// Supports AVX512_FP16.
     ///
     /// # Platforms
     /// ❌ AMD (reserved) ✅ Intel
     #[inline]
     pub const fn has_avx512_fp16(&self) -> bool {
         self.edx.contains(ExtendedFeaturesEdx::AVX512_FP16)
+    }
+
+    /// Supports AMX_TILE.
+    ///
+    /// # Platforms
+    /// ❌ AMD (reserved) ✅ Intel
+    #[inline]
+    pub const fn has_amx_tile(&self) -> bool {
+        self.edx.contains(ExtendedFeaturesEdx::AMX_TILE)
+    }
+
+    /// Supports AMX_INT8.
+    ///
+    /// # Platforms
+    /// ❌ AMD (reserved) ✅ Intel
+    #[inline]
+    pub const fn has_amx_int8(&self) -> bool {
+        self.edx.contains(ExtendedFeaturesEdx::AMX_INT8)
     }
 }
 
@@ -3852,6 +3879,8 @@ bitflags! {
         const AVX512_4VNNIW = 1 << 2;
         /// Bit 03: AVX512_4FMAPS. (Intel® Xeon Phi™ only).
         const AVX512_4FMAPS = 1 << 3;
+        /// Bit 08: AVX512_VP2INTERSECT.
+        const AVX512_VP2INTERSECT = 1 << 8;
         /// Bit 22: AMX-BF16. If 1, the processor supports tile computational operations on bfloat16 numbers.
         const AMX_BF16 = 1 << 22;
         /// Bit 23: AVX512_FP16.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,7 +521,7 @@ impl<R: CpuIdReader> CpuId<R> {
                 _eax: res.eax,
                 ebx: ExtendedFeaturesEbx::from_bits_truncate(res.ebx),
                 ecx: ExtendedFeaturesEcx::from_bits_truncate(res.ecx),
-                _edx: res.edx,
+                edx: ExtendedFeaturesEdx::from_bits_truncate(res.edx),
             })
         } else {
             None
@@ -3224,7 +3224,7 @@ pub struct ExtendedFeatures {
     _eax: u32,
     ebx: ExtendedFeaturesEbx,
     ecx: ExtendedFeaturesEcx,
-    _edx: u32,
+    edx: ExtendedFeaturesEdx,
 }
 
 impl ExtendedFeatures {
@@ -3671,6 +3671,42 @@ impl ExtendedFeatures {
     pub fn mawau_value(&self) -> u8 {
         get_bits(self.ecx.bits(), 17, 21) as u8
     }
+
+    /// Supports AVX512_4NNIW.
+    ///
+    /// # Platforms
+    /// ❌ AMD (reserved) ✅ Intel
+    #[inline]
+    pub const fn has_avx512_4nniw(&self) -> bool {
+        self.edx.contains(ExtendedFeaturesEdx::AVX512_4VNNIW)
+    }
+
+    /// Supports AVX512_4FMAPS.
+    ///
+    /// # Platforms
+    /// ❌ AMD (reserved) ✅ Intel
+    #[inline]
+    pub const fn has_avx512_4fmaps(&self) -> bool {
+        self.edx.contains(ExtendedFeaturesEdx::AVX512_4FMAPS)
+    }
+
+    /// Supports AMX_BF16.
+    ///
+    /// # Platforms
+    /// ❌ AMD (reserved) ✅ Intel
+    #[inline]
+    pub const fn has_amx_bf16(&self) -> bool {
+        self.edx.contains(ExtendedFeaturesEdx::AMX_BF16)
+    }
+
+    /// Supports AVX_FP16.
+    ///
+    /// # Platforms
+    /// ❌ AMD (reserved) ✅ Intel
+    #[inline]
+    pub const fn has_avx512_fp16(&self) -> bool {
+        self.edx.contains(ExtendedFeaturesEdx::AVX512_FP16)
+    }
 }
 
 impl Debug for ExtendedFeatures {
@@ -3805,6 +3841,25 @@ bitflags! {
 
         /// Bit 30: SGX_LC. Supports SGX Launch Configuration if 1.
         const SGX_LC = 1 << 30;
+    }
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct ExtendedFeaturesEdx: u32 {
+        /// Bit 02: AVX512_4VNNIW. (Intel® Xeon Phi™ only).
+        const AVX512_4VNNIW = 1 << 2;
+        /// Bit 03: AVX512_4FMAPS. (Intel® Xeon Phi™ only).
+        const AVX512_4FMAPS = 1 << 3;
+        /// Bit 22: AMX-BF16. If 1, the processor supports tile computational operations on bfloat16 numbers.
+        const AMX_BF16 = 1 << 22;
+        /// Bit 23: AVX512_FP16.
+        const AVX512_FP16 = 1 << 23;
+        /// Bit 24: AMX-TILE. If 1, the processor supports tile architecture
+        const AMX_TILE = 1 << 24;
+        /// Bit 24: AMX-INT8. If 1, the processor supports tile computational operations on 8-bit integers.
+        const AMX_INT8 = 1 << 25;
     }
 }
 

--- a/src/tests/i5_3337u.rs
+++ b/src/tests/i5_3337u.rs
@@ -291,6 +291,14 @@ fn extended_features() {
     assert!(tpfeatures2.has_smap());
     assert!(tpfeatures2.has_clflushopt());
     assert!(tpfeatures2.has_processor_trace());
+
+    assert!(!tpfeatures2.has_avx512_4vnniw());
+    assert!(!tpfeatures2.has_avx512_4fmaps());
+    assert!(!tpfeatures2.has_avx512_vp2intersect());
+    assert!(!tpfeatures2.has_amx_bf16());
+    assert!(!tpfeatures2.has_avx512_fp16());
+    assert!(!tpfeatures2.has_amx_tile());
+    assert!(!tpfeatures2.has_amx_int8());
 }
 
 #[test]

--- a/src/tests/i5_3337u.rs
+++ b/src/tests/i5_3337u.rs
@@ -239,7 +239,7 @@ fn extended_features() {
         _eax: 0,
         ebx: ExtendedFeaturesEbx::from_bits_truncate(641),
         ecx: ExtendedFeaturesEcx::from_bits_truncate(0),
-        _edx: 0,
+        edx: ExtendedFeaturesEdx::from_bits_truncate(0),
     };
     assert!(tpfeatures._eax == 0);
     assert!(tpfeatures.has_fsgsbase());
@@ -273,7 +273,7 @@ fn extended_features() {
             | ExtendedFeaturesEbx::CLFLUSHOPT
             | ExtendedFeaturesEbx::PROCESSOR_TRACE,
         ecx: ExtendedFeaturesEcx::from_bits_truncate(0),
-        _edx: 201326592,
+        edx: ExtendedFeaturesEdx::from_bits_truncate(201326592),
     };
 
     assert!(tpfeatures2.has_fsgsbase());


### PR DESCRIPTION
- Missing Extended features are those located at edx register and for leaf eax=7,ecx=0
- Implemented new struct for features at edx register to contain those features.
- Changed the display code by adding new features implemented.
