### PR TITLE
Add hygon into AMD vendor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ impl Vendor {
 
         match vi.as_str() {
             "GenuineIntel" => Vendor::Intel,
-            "AuthenticAMD" => Vendor::Amd,
+            "AuthenticAMD" | "HygonGenuine" => Vendor::Amd,
             _ => Vendor::Unknown(res.ebx, res.ecx, res.edx),
         }
     }


### PR DESCRIPTION
There are AMD arch processors made from vendors besides AMD, like Hygon.
Currently the vendor info check doesn't support such vendor, leading lots of function unusable in other AMD platform. 