### PR TITLE
annotate examples/serialize_deserialize.rs with correct features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["cli"]
 [[example]]
 name = "serialize_deserialize"
 path = "examples/serialize_deserialize.rs"
-required-features = ["serde_json"]
+required-features = ["serde_json", "serialize"]
 
 [features]
 std = []


### PR DESCRIPTION
Without this patch, this fails to compile:

```
cargo test --no-default-features --features serde_json
```