### PR TITLE
Fix detection of CET shadow stacks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3573,7 +3573,7 @@ impl ExtendedFeatures {
     /// ❓ AMD ✅ Intel
     #[inline]
     pub const fn has_cet_ss(&self) -> bool {
-        self.ecx.contains(ExtendedFeaturesEcx::GFNI)
+        self.ecx.contains(ExtendedFeaturesEcx::CETSS)
     }
 
     /// GFNI


### PR DESCRIPTION
Previously, the code used bit 8 of ECX (`ExtendedFeatures::GFNI`) to check for CET shadow stack support. Fix the function to use bit 7 of ECX (`ExtendedFeatures::CETSS`) instead.