### PR TITLE
vbmi

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3522,6 +3522,14 @@ impl ExtendedFeatures {
         self.ecx.contains(ExtendedFeaturesEcx::PREFETCHWT1)
     }
 
+    /// AVX512VBMI
+    ///
+    /// ✅ AMD ✅ Intel
+    #[inline]
+    pub const fn has_avx512vbmi(&self) -> bool {
+        self.ecx.contains(ExtendedFeaturesEcx::AVX512VBMI)
+    }
+
     /// Supports user-mode instruction prevention if 1.
     ///
     /// # Platforms
@@ -3562,7 +3570,7 @@ impl ExtendedFeatures {
     ///
     /// ✅ AMD ✅ Intel
     #[inline]
-    pub const fn has_av512vbmi2(&self) -> bool {
+    pub const fn has_avx512vbmi2(&self) -> bool {
         self.ecx.contains(ExtendedFeaturesEcx::AVX512VBMI2)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3569,6 +3569,15 @@ impl ExtendedFeatures {
     /// AVX512VBMI2
     ///
     /// ✅ AMD ✅ Intel
+    #[deprecated(since = "11.4.0", note = "Please use `has_avx512vbmi2` instead")]
+    #[inline]
+    pub const fn has_av512vbmi2(&self) -> bool {
+        self.ecx.contains(ExtendedFeaturesEcx::AVX512VBMI2)
+    }
+
+    /// AVX512VBMI2
+    ///
+    /// ✅ AMD ✅ Intel
     #[inline]
     pub const fn has_avx512vbmi2(&self) -> bool {
         self.ecx.contains(ExtendedFeaturesEcx::AVX512VBMI2)


### PR DESCRIPTION
1. add method `has_avx512vbmi`
2. fix typo `has_av512vbmi2`, the correct one is  `has_avx512vbmi2`