### PR TITLE
Leaf 8000_0001h EDX holds FFXSR, but feature is off by a bit

### DIFF
--- a/src/extended.rs
+++ b/src/extended.rs
@@ -423,7 +423,7 @@ bitflags! {
         const SYSCALL_SYSRET = 1 << 11;
         const EXECUTE_DISABLE = 1 << 20;
         const MMXEXT = 1 << 22;
-        const FFXSR = 1 << 24;
+        const FFXSR = 1 << 25;
         const GIB_PAGES = 1 << 26;
         const RDTSCP = 1 << 27;
         const I64BIT_MODE = 1 << 29;


### PR DESCRIPTION
In practice, FXSR and FFXSR are both set on processors from the last few decades, so mapping to FFXSR to bit 24 is not an obvious error. But it is actually indicated by bit 25, not 24.

From the APM volume 3 (24594 dated 2025-07-02) `CPUID Fn8000_0001_EDX Feature Identifiers`:
<img width="420" height="130" alt="a screenshot of the AMD APM showing bits 21 through 26 in this register" src="https://github.com/user-attachments/assets/8e7fe963-a89e-462e-aa91-c4fc8791c357" />
