### PR TITLE
APIs to write CPUID leaves

### DIFF
--- a/examples/synthetic.rs
+++ b/examples/synthetic.rs
@@ -2,7 +2,7 @@
 extern crate raw_cpuid;
 
 use raw_cpuid::{
-    ApmInfo, CpuIdReader, CpuIdResult, CpuIdWriter, ExtendedFeatureIdentification2,
+    ApmInfo, CpuIdDump, CpuIdReader, CpuIdResult, CpuIdWriter, ExtendedFeatureIdentification2,
     ExtendedFeatures, ExtendedProcessorFeatureIdentifiers, ExtendedState, ExtendedStateInfo,
     ExtendedTopologyLevel, FeatureInfo, L1CacheTlbInfo, L2And3CacheTlbInfo,
     PerformanceOptimizationInfo, ProcessorCapacityAndFeatureInfo, ProcessorTopologyInfo,
@@ -27,223 +27,6 @@ impl CpuidEntry {
             ebx: self.ebx,
             ecx: self.ecx,
             edx: self.edx,
-        }
-    }
-}
-
-#[derive(Clone)]
-enum LeafOrSubleaves {
-    Leaf(CpuIdResult),
-    Subleaf(HashMap<u32, CpuIdResult>),
-}
-
-// TODO: Clone is necessary because CpuIdReader wants it (for leaves with more complex subleaf
-// structures, like the extended topology info leaf)
-//
-// This implies that there's a full clone of the dump held on for those leaf-specific views, which
-// is unfortunate! It's also not yet really clear how to assemble those more complex leaves for
-// writer purposes.
-#[derive(Clone)]
-struct CpuIdDump {
-    leaves: HashMap<u32, LeafOrSubleaves>,
-}
-
-impl CpuIdDump {
-    // TODO: probably should just take vendor in the initial constructor here
-    // (that also lets this pick the right leaf/subleaf fallback behavior from the get-go)
-    fn new() -> Self {
-        Self {
-            leaves: HashMap::new(),
-        }
-    }
-}
-
-const DEFAULT_LEAF: CpuIdResult = CpuIdResult {
-    eax: 0,
-    ebx: 0,
-    ecx: 0,
-    edx: 0,
-};
-
-impl CpuIdWriter for CpuIdDump {
-    fn set_leaf(&mut self, leaf: u32, mut bits: Option<CpuIdResult>) {
-        // Many bits in 8000_0001h EDX, if present, mirror leaf 1h EDX. Maintain that before
-        // storing the bits.
-        if let Some(bits) = bits.as_mut() {
-            const MIRROR_MASK: u32 = 0b0000_0001_1000_0011_1111_0011_1111_1111;
-
-            let update = if leaf == 0x0000_0001 {
-                // We're updating leaf 1h, so go fix up leaf 8000_0001h (if present)
-                match self.leaves.get_mut(&0x8000_0001) {
-                    Some(LeafOrSubleaves::Leaf(ext_info)) => {
-                        ext_info.edx &= !MIRROR_MASK;
-                        ext_info.edx |= bits.edx & MIRROR_MASK;
-                    }
-                    Some(_) => {
-                        panic!("extended feature information leaf (8000_0001h) had subleaves?");
-                    }
-                    None => {
-                        // No leaf 8000_0001h to mirror to (yet?)
-                    }
-                }
-            } else if leaf == 0x8000_0001 {
-                match self.leaves.get(&0x0000_0001) {
-                    Some(LeafOrSubleaves::Leaf(prior_bits)) => {
-                        bits.edx &= !MIRROR_MASK;
-                        bits.edx |= prior_bits.edx & MIRROR_MASK;
-                    }
-                    Some(_) => {
-                        panic!("feature information leaf (01h) had subleaves?");
-                    }
-                    None => {
-                        // No leaf 1h to shadow (yet?)
-                    }
-                }
-            };
-        }
-
-        if let Some(bits) = bits {
-            self.leaves.insert(leaf, LeafOrSubleaves::Leaf(bits));
-        } else {
-            self.leaves.remove(&leaf);
-        }
-
-        self.update_max_leaves();
-    }
-    fn set_subleaf(&mut self, leaf: u32, subleaf: u32, bits: Option<CpuIdResult>) {
-        if let Some(bits) = bits {
-            match self
-                .leaves
-                .entry(leaf)
-                .or_insert(LeafOrSubleaves::Subleaf(HashMap::new()))
-            {
-                LeafOrSubleaves::Leaf(_) => {
-                    panic!("adding a subleaf where there's a leaf. no");
-                }
-                LeafOrSubleaves::Subleaf(leaves) => {
-                    leaves.insert(subleaf, bits);
-                }
-            }
-        } else {
-            self.leaves.get_mut(&leaf).map(|ent| {
-                if let LeafOrSubleaves::Subleaf(leaves) = ent {
-                    leaves.remove(&subleaf);
-                } else {
-                    panic!("removing a subleaf when there's a leaf. no");
-                }
-            });
-        }
-
-        self.update_max_leaves();
-    }
-}
-
-impl CpuIdDump {
-    fn update_max_leaves(&mut self) {
-        let mut max_standard = None;
-        let mut max_hv = None;
-        let mut max_extended = None;
-
-        for (idx, k) in self.leaves.keys().enumerate() {
-            let k = *k;
-            if k < 0x40000000 {
-                max_standard = Some(match max_standard {
-                    None => k,
-                    Some(prev) => std::cmp::max(k, prev),
-                });
-            } else if k < 0x80000000 {
-                max_hv = Some(match max_hv {
-                    None => k,
-                    Some(prev) => std::cmp::max(k, prev),
-                });
-            } else if k < 0xc0000000 {
-                max_extended = Some(match max_extended {
-                    None => k,
-                    Some(prev) => std::cmp::max(k, prev),
-                });
-            }
-        }
-
-        if let Some(eax) = max_standard {
-            match self
-                .leaves
-                .entry(0)
-                .or_insert(LeafOrSubleaves::Leaf(CpuIdResult::empty()))
-            {
-                LeafOrSubleaves::Leaf(leaf) => {
-                    leaf.eax = eax;
-                }
-                _ => {
-                    panic!("cannot update leaf 1.EAX: leaf has subleaves?");
-                }
-            }
-        }
-
-        if let Some(eax) = max_hv {
-            match self
-                .leaves
-                .entry(0x40000000)
-                .or_insert(LeafOrSubleaves::Leaf(CpuIdResult::empty()))
-            {
-                LeafOrSubleaves::Leaf(leaf) => {
-                    leaf.eax = eax;
-                }
-                _ => {
-                    panic!("cannot update leaf 0x40000000.EAX: leaf has subleaves?");
-                }
-            }
-        }
-
-        if let Some(eax) = max_extended {
-            match self
-                .leaves
-                .entry(0x80000000)
-                .or_insert(LeafOrSubleaves::Leaf(CpuIdResult::empty()))
-            {
-                LeafOrSubleaves::Leaf(leaf) => {
-                    leaf.eax = eax;
-                }
-                _ => {
-                    panic!("cannot update leaf 0x80000000.EAX: leaf has subleaves?");
-                }
-            }
-        }
-    }
-}
-
-impl CpuIdReader for CpuIdDump {
-    fn cpuid1(&self, leaf: u32) -> CpuIdResult {
-        match self.leaves.get(&leaf) {
-            Some(LeafOrSubleaves::Leaf(res)) => *res,
-            Some(LeafOrSubleaves::Subleaf(subleaves)) => {
-                *subleaves.get(&0).unwrap_or_else(|| {
-                    // TODO: vendor-specific fallback behavior
-                    &DEFAULT_LEAF
-                })
-            }
-            None => {
-                // TODO: more vendor-specific fallback behavior
-                DEFAULT_LEAF
-            }
-        }
-    }
-
-    fn cpuid2(&self, leaf: u32, subleaf: u32) -> CpuIdResult {
-        match self.leaves.get(&leaf) {
-            Some(LeafOrSubleaves::Leaf(res)) => {
-                // TODO: vendor-specific fallback behavior
-                DEFAULT_LEAF
-            }
-            Some(LeafOrSubleaves::Subleaf(subleaves)) => {
-                *subleaves.get(&subleaf).unwrap_or_else(|| {
-                    // TODO: vendor-specific fallback behavior
-                    &DEFAULT_LEAF
-                })
-            }
-            None => {
-                // TODO: more vendor-specific fallback behavior
-                DEFAULT_LEAF
-            }
         }
     }
 }
@@ -417,7 +200,7 @@ fn synthetic_milan() -> CpuIdDump {
     // bit 27 is reserved
 
     leaf.set_htt(false); // managed dynamically in practice
-    // bits 29-31 are not used here.
+                         // bits 29-31 are not used here.
 
     // Milan Leaf 1 EAX: 0x00A00F11
     // Milan Leaf 1 EBX: 0xXXYY0800
@@ -470,7 +253,7 @@ fn synthetic_milan() -> CpuIdDump {
 
     leaf.set_smap(true);
     leaf.set_avx512_ifma(false); // Not on Milan
-    // Bit 22 is reserved on AMD
+                                 // Bit 22 is reserved on AMD
     leaf.set_clflushopt(true);
 
     leaf.set_clwb(true);
@@ -591,6 +374,7 @@ fn synthetic_milan() -> CpuIdDump {
     leaf.set_lwp(false);
 
     leaf.set_fma4(false); // Not on Milan
+
     // Bits 17-19 are reserved
 
     // Bit 20 is reserved

--- a/examples/synthetic.rs
+++ b/examples/synthetic.rs
@@ -1,0 +1,680 @@
+//! An example of loading and printing features from a CPUID dump.
+extern crate raw_cpuid;
+
+use raw_cpuid::{CpuIdReader, CpuIdResult, CpuIdWriter, FeatureInfo, Vendor, VendorInfo, ThermalPowerInfo, ExtendedFeatures, ExtendedTopologyLevel, ExtendedState, ExtendedStateInfo, L1CacheTlbInfo, L2And3CacheTlbInfo, ApmInfo, ProcessorCapacityAndFeatureInfo, PerformanceOptimizationInfo, Tlb1gbPageInfo};
+use std::collections::HashMap;
+
+#[derive(Debug)]
+struct CpuidEntry {
+    leaf: u32,
+    subleaf: Option<u32>,
+    eax: u32,
+    ebx: u32,
+    ecx: u32,
+    edx: u32,
+}
+
+impl CpuidEntry {
+    pub fn just_regs(&self) -> CpuIdResult {
+        CpuIdResult {
+            eax: self.eax,
+            ebx: self.ebx,
+            ecx: self.ecx,
+            edx: self.edx,
+        }
+    }
+}
+
+
+#[derive(Clone)]
+enum LeafOrSubleaves {
+    Leaf(CpuIdResult),
+    Subleaf(HashMap<u32, CpuIdResult>),
+}
+
+// TODO: Clone is necessary because CpuIdReader wants it (for leaves with more complex subleaf
+// structures, like the extended topology info leaf)
+//
+// This implies that there's a full clone of the dump held on for those leaf-specific views, which
+// is unfortunate! It's also not yet really clear how to assemble those more complex leaves for
+// writer purposes.
+#[derive(Clone)]
+struct CpuIdDump {
+    leaves: HashMap<u32, LeafOrSubleaves>,
+}
+
+impl CpuIdDump {
+    // TODO: probably should just take vendor in the initial constructor here
+    // (that also lets this pick the right leaf/subleaf fallback behavior from the get-go)
+    fn new() -> Self {
+        Self {
+            leaves: HashMap::new()
+        }
+    }
+}
+
+const DEFAULT_LEAF: CpuIdResult = CpuIdResult {
+    eax: 0,
+    ebx: 0,
+    ecx: 0,
+    edx: 0,
+};
+
+impl CpuIdWriter for CpuIdDump {
+    fn set_leaf(&mut self, leaf: u32, bits: Option<CpuIdResult>) {
+        if let Some(bits) = bits {
+            self.leaves.insert(leaf, LeafOrSubleaves::Leaf(bits));
+        } else {
+            self.leaves.remove(&leaf);
+        }
+
+        self.update_max_leaves();
+    }
+    fn set_subleaf(&mut self, leaf: u32, subleaf: u32, bits: Option<CpuIdResult>) {
+        if let Some(bits) = bits {
+            match self.leaves.entry(leaf).or_insert(LeafOrSubleaves::Subleaf(HashMap::new())) {
+                LeafOrSubleaves::Leaf(_) => {
+                    panic!("adding a subleaf where there's a leaf. no");
+                }
+                LeafOrSubleaves::Subleaf(leaves) => {
+                    leaves.insert(subleaf, bits);
+                }
+            }
+        } else {
+            self.leaves.get_mut(&leaf).map(|ent| if let LeafOrSubleaves::Subleaf(leaves) = ent {
+                leaves.remove(&subleaf);
+            } else {
+                panic!("removing a subleaf when there's a leaf. no");
+            });
+        }
+
+        self.update_max_leaves();
+    }
+}
+
+impl CpuIdDump {
+    fn update_max_leaves(&mut self) {
+        let mut max_standard = None;
+        let mut max_hv = None;
+        let mut max_extended = None;
+
+        for (idx, k) in self.leaves.keys().enumerate() {
+            let k = *k;
+            if k < 0x40000000 {
+                max_standard = Some(match max_standard {
+                    None => k,
+                    Some(prev) => std::cmp::max(k, prev),
+                });
+            } else if k < 0x80000000 {
+                max_hv = Some(match max_hv {
+                    None => k,
+                    Some(prev) => std::cmp::max(k, prev),
+                });
+            } else if k < 0xc0000000 {
+                max_extended = Some(match max_extended {
+                    None => k,
+                    Some(prev) => std::cmp::max(k, prev),
+                });
+            }
+        }
+
+        if let Some(eax) = max_standard {
+            match self.leaves.entry(0).or_insert(LeafOrSubleaves::Leaf(CpuIdResult::empty())) {
+                LeafOrSubleaves::Leaf(leaf) => {
+                    leaf.eax = eax;
+                }
+                _ => {
+                    panic!("cannot update leaf 1.EAX: leaf has subleaves?");
+                }
+            }
+        }
+
+        if let Some(eax) = max_hv {
+            match self.leaves.entry(0x40000000).or_insert(LeafOrSubleaves::Leaf(CpuIdResult::empty())) {
+                LeafOrSubleaves::Leaf(leaf) => {
+                    leaf.eax = eax;
+                }
+                _ => {
+                    panic!("cannot update leaf 0x40000000.EAX: leaf has subleaves?");
+                }
+            }
+        }
+
+        if let Some(eax) = max_extended {
+            match self.leaves.entry(0x80000000).or_insert(LeafOrSubleaves::Leaf(CpuIdResult::empty())) {
+                LeafOrSubleaves::Leaf(leaf) => {
+                    leaf.eax = eax;
+                }
+                _ => {
+                    panic!("cannot update leaf 0x80000000.EAX: leaf has subleaves?");
+                }
+            }
+        }
+    }
+}
+
+impl CpuIdReader for CpuIdDump {
+    fn cpuid1(&self, leaf: u32) -> CpuIdResult {
+        match self.leaves.get(&leaf) {
+            Some(LeafOrSubleaves::Leaf(res)) => *res,
+            Some(LeafOrSubleaves::Subleaf(subleaves)) => {
+                *subleaves.get(&0).unwrap_or_else(|| {
+                    // TODO: vendor-specific fallback behavior
+                    &DEFAULT_LEAF
+                })
+            }
+            None => {
+                // TODO: more vendor-specific fallback behavior
+                DEFAULT_LEAF
+            }
+        }
+    }
+
+    fn cpuid2(&self, leaf: u32, subleaf: u32) -> CpuIdResult {
+        match self.leaves.get(&leaf) {
+            Some(LeafOrSubleaves::Leaf(res)) => {
+                // TODO: vendor-specific fallback behavior
+                DEFAULT_LEAF
+            }
+            Some(LeafOrSubleaves::Subleaf(subleaves)) => {
+                *subleaves.get(&subleaf).unwrap_or_else(|| {
+                    // TODO: vendor-specific fallback behavior
+                    &DEFAULT_LEAF
+                })
+            }
+            None => {
+                // TODO: more vendor-specific fallback behavior
+                DEFAULT_LEAF
+            }
+        }
+    }
+}
+
+macro_rules! cpuid_leaf {
+    ($leaf:literal, $eax:literal, $ebx:literal, $ecx:literal, $edx:literal) => {
+        CpuidEntry {
+            leaf: $leaf,
+            subleaf: None,
+            eax: $eax,
+            ebx: $ebx,
+            ecx: $ecx,
+            edx: $edx,
+        }
+    };
+}
+
+macro_rules! cpuid_subleaf {
+    ($leaf:literal, $sl:literal, $eax:literal, $ebx:literal, $ecx:literal, $edx:literal) => {
+        CpuidEntry {
+            leaf: $leaf,
+            subleaf: Some($sl),
+            eax: $eax,
+            ebx: $ebx,
+            ecx: $ecx,
+            edx: $edx,
+        }
+    };
+}
+
+const MILAN_CPUID: [CpuidEntry; 32] = [
+    cpuid_leaf!(0x0, 0x0000000D, 0x68747541, 0x444D4163, 0x69746E65),
+    cpuid_leaf!(0x1, 0x00A00F11, 0x00000800, 0xF6D83203, 0x078BFBFF),
+    cpuid_leaf!(0x5, 0x00000000, 0x00000000, 0x00000000, 0x00000000),
+    cpuid_leaf!(0x6, 0x00000004, 0x00000000, 0x00000000, 0x00000000),
+    cpuid_subleaf!(
+        0x7, 0x0, 0x00000000, 0x219803A9, 0x00000600, 0x00000010
+    ),
+    cpuid_subleaf!(
+        0xB, 0x0, 0x00000001, 0x00000002, 0x00000100, 0x00000000
+    ),
+    cpuid_subleaf!(
+        0xB, 0x1, 0x00000000, 0x00000000, 0x00000201, 0x00000000
+    ),
+    cpuid_subleaf!(
+        0xB, 0x2, 0x00000000, 0x00000000, 0x00000002, 0x00000000
+    ),
+    cpuid_subleaf!(
+        0xD, 0x0, 0x00000007, 0x00000340, 0x00000340, 0x00000000
+    ),
+    cpuid_subleaf!(
+        0xD, 0x1, 0x00000007, 0x00000340, 0x00000000, 0x00000000
+    ),
+    cpuid_subleaf!(
+        0xD, 0x2, 0x00000100, 0x00000240, 0x00000000, 0x00000000
+    ),
+    cpuid_leaf!(0x80000000, 0x80000021, 0x68747541, 0x444D4163, 0x69746E65),
+    // ecx bit 23 should be flipped true at some point, but is currently
+    // hidden and will continue to be for the moment.
+    // ecx bit 3 should be masked, but is is not and advertises support for
+    // unsupported extensions to LAPIC space.
+    //
+    // RFD 314 talks about these bits more, but we currently allow them to
+    // be wrong as they have been wrong before and we'll get to them
+    // individually later.
+    cpuid_leaf!(0x80000001, 0x00A00F11, 0x40000000, 0x444001F1, 0x27D3FBFF),
+    cpuid_leaf!(0x80000002, 0x20444D41, 0x43595045, 0x31373720, 0x36205033),
+    cpuid_leaf!(0x80000003, 0x6F432D34, 0x50206572, 0x65636F72, 0x726F7373),
+    cpuid_leaf!(0x80000004, 0x20202020, 0x20202020, 0x20202020, 0x00202020),
+    cpuid_leaf!(0x80000005, 0xFF40FF40, 0xFF40FF40, 0x20080140, 0x20080140),
+    cpuid_leaf!(0x80000006, 0x48002200, 0x68004200, 0x02006140, 0x08009140),
+    cpuid_leaf!(0x80000007, 0x00000000, 0x00000000, 0x00000000, 0x00000100),
+    cpuid_leaf!(0x80000008, 0x00003030, 0x00000205, 0x00000000, 0x00000000),
+    cpuid_leaf!(0x8000000A, 0x00000000, 0x00000000, 0x00000000, 0x00000000),
+    cpuid_leaf!(0x80000019, 0xF040F040, 0xF0400000, 0x00000000, 0x00000000),
+    cpuid_leaf!(0x8000001A, 0x00000006, 0x00000000, 0x00000000, 0x00000000),
+    cpuid_leaf!(0x8000001B, 0x00000000, 0x00000000, 0x00000000, 0x00000000),
+    cpuid_leaf!(0x8000001C, 0x00000000, 0x00000000, 0x00000000, 0x00000000),
+    cpuid_subleaf!(
+        0x8000001D, 0x0, 0x00000121, 0x01C0003F, 0x0000003F, 0x00000000
+    ),
+    cpuid_subleaf!(
+        0x8000001D, 0x1, 0x00000122, 0x01C0003F, 0x0000003F, 0x00000000
+    ),
+    cpuid_subleaf!(
+        0x8000001D, 0x2, 0x00000143, 0x01C0003F, 0x000003FF, 0x00000002
+    ),
+    cpuid_subleaf!(
+        0x8000001D, 0x3, 0x00000163, 0x03C0003F, 0x00007FFF, 0x00000001
+    ),
+    cpuid_leaf!(0x8000001E, 0x00000000, 0x00000100, 0x00000000, 0x00000000),
+    cpuid_leaf!(0x8000001F, 0x00000000, 0x00000000, 0x00000000, 0x00000000),
+    cpuid_leaf!(0x80000021, 0x00000045, 0x00000000, 0x00000000, 0x00000000),
+];
+
+fn synthetic_milan() -> CpuIdDump {
+    let mut bits = CpuIdDump::new();
+    let mut cpuid = raw_cpuid::CpuId::with_cpuid_reader(bits);
+    let mut leaf = VendorInfo::amd();
+    cpuid.set_vendor_info(Some(leaf));
+
+    let mut leaf = FeatureInfo::new(Vendor::Amd);
+
+    // Set up EAX
+    leaf.set_extended_family_id(0x00);
+    leaf.set_extended_family_id(0xA);
+    leaf.set_base_family_id(0x0F);
+    leaf.set_base_model_id(0x01);
+    leaf.set_stepping_id(0x01);
+
+    // Set up EBX
+    leaf.set_brand_index(0); //
+    leaf.set_cflush_cache_line_size(8);
+    leaf.set_initial_local_apic_id(0); // Populated dynamically in a real system.
+    leaf.set_max_logical_processor_ids(0); // Populated dynamically in a real system.
+
+    // Set up ECX
+    leaf.set_sse3(true);
+    leaf.set_pclmulqdq(true);
+    leaf.set_ds_area(false);
+    leaf.set_monitor_mwait(false);
+
+    leaf.set_cpl(false);
+    leaf.set_vmx(false);
+    leaf.set_smx(false);
+    leaf.set_eist(false);
+
+    leaf.set_tm2(false);
+    leaf.set_ssse3(true);
+    leaf.set_cnxtid(false);
+    // bit 11 is reserved
+
+    leaf.set_fma(true);
+    leaf.set_cmpxchg16b(true);
+    // bit 14 is reserved
+    leaf.set_pdcm(false);
+
+    //bit 16 is reserved
+    leaf.set_pcid(false);
+    leaf.set_dca(false);
+    leaf.set_sse41(true);
+
+    leaf.set_sse42(true);
+    leaf.set_x2apic(false); // GOT THIS WRONG IN OMICRON UGHGHGHGGHH
+    leaf.set_movbe(true);
+    leaf.set_popcnt(true);
+
+    leaf.set_tsc_deadline(false);
+    leaf.set_aesni(true);
+    leaf.set_xsave(true);
+    leaf.set_oxsave(false); // managed dynamically in practice
+
+    leaf.set_avx(true);
+    leaf.set_f16c(true);
+    leaf.set_rdrand(true);
+    leaf.set_hypervisor(true); // This CPUID leaf will be presented to hypervisor guests
+
+    // Set up EDX
+    leaf.set_fpu(true);
+    leaf.set_vme(true);
+    leaf.set_de(true);
+    leaf.set_pse(true);
+
+    leaf.set_tsc(true);
+    leaf.set_msr(true);
+    leaf.set_pae(true);
+    leaf.set_mce(true);
+
+    leaf.set_cmpxchg8b(true);
+    leaf.set_apic(true);
+    // bit 10 is reserved
+    leaf.set_sysenter_sysexit(true);
+
+    leaf.set_mtrr(true);
+    leaf.set_pge(true);
+    leaf.set_mca(true);
+    leaf.set_cmov(true);
+
+    leaf.set_pat(true);
+    leaf.set_pse36(true);
+    // bit 18 is reserved
+    leaf.set_clflush(true);
+
+    // bit 20 is reserved
+    // bit 21 is reserved
+    // bit 22 is reserved
+    leaf.set_mmx(true);
+
+    leaf.set_fxsave_fxstor(true);
+    leaf.set_sse(true);
+    leaf.set_sse2(true);
+    // bit 27 is reserved
+
+    leaf.set_htt(false); // managed dynamically in practice
+    // bits 29-31 are not used here.
+
+    // Milan Leaf 1 EAX: 0x00A00F11
+    // Milan Leaf 1 EBX: 0xXXYY0800
+    // Milan Leaf 1 ECX: 0xF6F83203
+    // Milan Leaf 1 EDX: 0x078BFBFF
+    cpuid.set_feature_info(Some(leaf));
+
+    // Leaf 2, 3, 4: all skipped on AMD
+
+    // Leaf 5: Monitor and MWait. All zero here.
+    cpuid.set_monitor_mwait_info(None);
+
+    // Leaf 6: Power management and .. some feature bits.
+    let mut leaf = ThermalPowerInfo::empty();
+    leaf.set_arat(true);
+    leaf.set_hw_coord_feedback(false);
+
+    // Milan Leaf 6 EAX 0x00000004
+    // Milan Leaf 6 EBX 0x00000004
+    // Milan Leaf 6 ECX 0x00000004
+    // Milan Leaf 6 EDX 0x00000004
+    cpuid.set_thermal_power_info(Some(leaf));
+
+    // Leaf 7: Extended features
+    let mut leaf = ExtendedFeatures::new();
+    leaf.set_fsgsbase(true);
+    leaf.set_tsc_adjust_msr(false);
+    leaf.set_sgx(false);
+    leaf.set_bmi1(true);
+
+    leaf.set_hle(false);
+    leaf.set_avx2(true);
+    leaf.set_fdp(false);
+    leaf.set_smep(true);
+
+    leaf.set_bmi2(true);
+    leaf.set_rep_movsb_stosb(true); // ERMS
+    leaf.set_invpcid(false);
+    // Bit 11 is reserved on AMD
+
+    // PQM (bit 12) is clear here
+    // Bit 13 is reserved on AMD
+    // Bit 14 is reserved on AMD
+    // Bit 15 is reserved on AMD
+
+    leaf.set_avx512f(false); // Not on Milan
+    leaf.set_avx512dq(false); // Not on Milan
+    leaf.set_rdseed(false); // False here
+    leaf.set_adx(true);
+
+    leaf.set_smap(true);
+    leaf.set_avx512_ifma(false); // Not on Milan
+    // Bit 22 is reserved on AMD
+    leaf.set_clflushopt(true);
+
+    leaf.set_clwb(true);
+    // Bit 25 is reserved on AMD
+    // Bit 26 is reserved on AMD
+    // Bit 27 is reserved on AMD
+
+    leaf.set_avx512cd(false); // Not on Milan
+    leaf.set_sha(true);
+    leaf.set_avx512bw(false); // Not on Milan
+    leaf.set_avx512vl(false); // Not on Milan
+
+    // Set up leaf 7 ECX
+
+    // Bit 0 is reserved on AMD
+    leaf.set_avx512vbmi(false);
+    leaf.set_umip(false);
+    leaf.set_pku(false);
+
+    leaf.set_ospke(false);
+    // Bit 5 is reserved on AMD
+    leaf.set_avx512vbmi2(false);
+    leaf.set_cet_ss(false);
+
+    leaf.set_gfni(false); // TODO: milan??
+    leaf.set_vaes(true);
+    leaf.set_vpclmulqdq(true);
+    leaf.set_avx512vnni(false);
+
+    leaf.set_avx512bitalg(false);
+    // Bit 13 is reserved on AMD
+    leaf.set_avx512vpopcntdq(false);
+    // Bit 15 is reserved on AMD
+
+    // Bits 16 through 31 are either reserved or zero on Milan.
+
+    // Set up leaf 7 EDX
+    leaf.set_fsrm(true);
+    cpuid.set_extended_feature_info(Some(leaf));
+
+    // Set up extended topology info (leaf Bh)
+    let mut levels = Vec::new();
+
+    let mut topo_level1 = ExtendedTopologyLevel::empty();
+    // EAX
+    // These perhaps should be dynamic based on SMT or no?
+    topo_level1.set_shift_right_for_next_apic_id(1);
+    // EBX
+    topo_level1.set_processors(2);
+    // ECX
+    topo_level1.set_level_number(0);
+    topo_level1.set_level_type(1); // If there's no SMT, there should be no SMT right..?
+
+    levels.push(topo_level1);
+
+    let mut topo_level2 = ExtendedTopologyLevel::empty();
+    // ECX
+    topo_level2.set_level_number(1);
+    topo_level2.set_level_type(2);
+
+    levels.push(topo_level2);
+
+    let mut topo_level3 = ExtendedTopologyLevel::empty();
+    // ECX
+    topo_level3.set_level_number(2);
+    topo_level3.set_level_type(0); // This level is invalid.
+
+    levels.push(topo_level3);
+    cpuid.set_extended_topology_info(Some(levels.as_slice()));
+
+    // TODO: ok, kind of messed up to have to pass a `CpuIdDump` here..
+    let mut state = ExtendedStateInfo::empty(CpuIdDump::new());
+    state.set_xcr0_supports_legacy_x87(true);
+    state.set_xcr0_supports_sse_128(true);
+    state.set_xcr0_supports_avx_256(true);
+    state.set_xsave_area_size_enabled_features(0x340); // Populated dynamically in a real system.
+    state.set_xsave_area_size_supported_features(0x340);
+
+    state.set_xsaveopt(true);
+    state.set_xsavec(true);
+    state.set_xgetbv(true);
+    state.set_xsave_size(0x340);
+
+    let mut leaves = state.into_leaves().to_vec();
+    let mut ymm_state = ExtendedState::empty();
+    ymm_state.set_size(0x100);
+    ymm_state.set_offset(0x240);
+    leaves.push(Some(ymm_state.into_leaf()));
+
+    cpuid.set_extended_state_info(Some(&leaves[..]));
+
+    // TODO: figure out leaves 8000_0000/8000_0001
+
+    // Leaves 8000_0002 through 8000_0005
+    cpuid.set_processor_brand_string(Some(b"AMD EPYC 7713P 64-Core Processor"));
+
+    // Set up L1 cache+TLB info (leaf 8000_0005h)
+    let mut leaf = L1CacheTlbInfo::empty();
+
+    leaf.set_itlb_2m_4m_size(0x40);
+    leaf.set_itlb_2m_4m_associativity(0xff);
+    leaf.set_dtlb_2m_4m_size(0x40);
+    leaf.set_dtlb_2m_4m_associativity(0xff);
+
+    leaf.set_itlb_4k_size(0x40);
+    leaf.set_itlb_4k_associativity(0xff);
+    leaf.set_dtlb_4k_size(0x40);
+    leaf.set_dtlb_4k_associativity(0xff);
+
+    leaf.set_dcache_line_size(0x40);
+    leaf.set_dcache_lines_per_tag(0x01);
+    leaf.set_dcache_associativity(0x08);
+    leaf.set_dcache_size(0x20);
+
+    leaf.set_icache_line_size(0x40);
+    leaf.set_icache_lines_per_tag(0x01);
+    leaf.set_icache_associativity(0x08);
+    leaf.set_icache_size(0x20);
+
+    cpuid.set_l1_cache_and_tlb_info(Some(leaf));
+
+    // Set up L2 and L3 cache+TLB info (leaf 8000_0006h)
+    let mut leaf = L2And3CacheTlbInfo::empty();
+
+    // Set up leaf 8000_0006h EAX
+    leaf.set_itlb_2m_4m_size(0x200);
+    leaf.set_itlb_2m_4m_associativity(0x2);
+    leaf.set_dtlb_2m_4m_size(0x800);
+    leaf.set_dtlb_2m_4m_associativity(0x4);
+
+    // Set up leaf 8000_0006h EBX
+    leaf.set_itlb_4k_size(0x200);
+    leaf.set_itlb_4k_associativity(0x4);
+    leaf.set_dtlb_4k_size(0x800);
+    leaf.set_dtlb_4k_associativity(0x6);
+
+    // Set up leaf 8000_0006h ECX
+    leaf.set_l2cache_line_size(0x40);
+    leaf.set_l2cache_lines_per_tag(0x1);
+    leaf.set_l2cache_associativity(0x6);
+    leaf.set_l2cache_size(0x0200);
+
+    // Set up leaf 8000_0006h EDX
+    leaf.set_l3cache_line_size(0x40);
+    leaf.set_l3cache_lines_per_tag(0x1);
+    leaf.set_l3cache_associativity(0x9);
+    leaf.set_l3cache_size(0x0800);
+
+    cpuid.set_l2_l3_cache_and_tlb_info(Some(leaf));
+
+    // Set up advanced power management info (leaf 8000_0007h)
+    let mut leaf = ApmInfo::empty();
+    leaf.set_invariant_tsc(true);
+    cpuid.set_advanced_power_mgmt_info(Some(leaf));
+
+    // Set up processor capacity info (leaf 8000_0008h)
+    let mut leaf = ProcessorCapacityAndFeatureInfo::empty();
+
+    // Set up leaf 8000_0008 EAX
+    leaf.set_physical_address_bits(0x30); // TODO: BREAKING
+    leaf.set_linear_address_bits(0x30); // TODO: BREAKING
+    leaf.set_guest_physical_address_bits(0); // TODO: BREAKING
+
+    // St up leaf 8000_0008 EBX
+    leaf.set_cl_zero(true);
+    leaf.set_restore_fp_error_ptrs(true);
+    leaf.set_wbnoinvd(true);
+
+    leaf.set_num_phys_threads(1); // Populated dynamically in a real system.
+    leaf.set_apic_id_size(0);
+    leaf.set_perf_tsc_size(0);
+
+    leaf.set_invlpgb_max_pages(0); // TODO: BREAKING
+    leaf.set_max_rdpru_id(0); // TODO: BREAKING
+
+    cpuid.set_processor_capacity_feature_info(Some(leaf));
+
+    // Set up TODO: (leaf 8000_000Ah)
+
+    // Set up TLB information for 1GiB pages (leaf 8000_0019h)
+    let mut leaf = Tlb1gbPageInfo::empty();
+    leaf.set_dtlb_l1_1gb_associativity(0xF);
+    leaf.set_dtlb_l1_1gb_size(0x40);
+    leaf.set_itlb_l1_1gb_associativity(0xF);
+    leaf.set_itlb_l1_1gb_size(0x40);
+    leaf.set_dtlb_l2_1gb_associativity(0xF);
+    leaf.set_dtlb_l2_1gb_size(0x40);
+    leaf.set_itlb_l1_1gb_associativity(0);
+    leaf.set_itlb_l1_1gb_size(0);
+    cpuid.set_tlb_1gb_page_info(Some(leaf)); // TODO: Would zero this
+
+    // Set up processor optimization info (leaf 8000_001Ah)
+    let mut leaf = PerformanceOptimizationInfo::empty();
+    leaf.set_movu(true);
+    leaf.set_fp256(true);
+    cpuid.set_performance_optimization_info(Some(leaf));
+
+    // Leaf 8000_001B
+    // TODO: no support for leaf 1B?
+    // Leaf 8000_001C
+    // TODO: no support for leaf 1C?
+    // Leaf 8000_001D
+
+    // Leaf 8000_001Eh EBX bit 8 needs attention.
+    cpuid.set_processor_topology_info(None);
+    cpuid.set_memory_encryption_info(None);
+
+    cpuid.into_source()
+}
+
+fn main() {
+    let synthetic_milan = synthetic_milan();
+
+    for leaf in MILAN_CPUID.iter() {
+        let synth = if let Some(subleaf) = leaf.subleaf {
+            synthetic_milan.cpuid2(leaf.leaf, subleaf)
+        } else {
+            synthetic_milan.cpuid1(leaf.leaf)
+        };
+
+        let regs = leaf.just_regs();
+
+        let place = match leaf.subleaf {
+            Some(subleaf) => format!("leaf {:08x}h.{}h", leaf.leaf, subleaf),
+            None => format!("leaf {:08x}h", leaf.leaf)
+        };
+
+        if regs.eax != synth.eax {
+            panic!("{}: eax different: expected {:08x}, was {:08x}", place, regs.eax, synth.eax);
+        }
+
+        if regs.ebx != synth.ebx {
+            panic!("{}: ebx different: expected {:08x}, was {:08x}", place, regs.ebx, synth.ebx);
+        }
+
+        if regs.ecx != synth.ecx {
+            panic!("{}: ecx different: expected {:08x}, was {:08x}", place, regs.ecx, synth.ecx);
+        }
+
+        if regs.edx != synth.edx {
+            panic!("{}: edx different: expected {:08x}, was {:08x}", place, regs.edx, synth.edx);
+        }
+    }
+}

--- a/src/display.rs
+++ b/src/display.rs
@@ -1368,4 +1368,217 @@ pub fn markdown<R: crate::CpuIdReader>(cpuid: crate::CpuId<R>) {
             ],
         );
     }
+
+    if let Some(info) = cpuid.get_pqos_extended_feature_info() {
+        print_title(&skin, "Platform Quality of Service (0x8000_0020/0):");
+        table2(
+            &skin,
+            &[
+                RowGen::tuple("Memory Bandwidth Enforcement", info.has_l3mbe()),
+                RowGen::tuple("Slow Memory Bandwidth Enforcement", info.has_l3smbe()),
+                RowGen::tuple("Bandwidth Monitoring Event Configuration", info.has_bmec()),
+                RowGen::tuple("L3 Range Reservation", info.has_l3rr()),
+                RowGen::tuple("Assignable Bandwidth Monitoring Counters", info.has_abmc()),
+                RowGen::tuple(
+                    "Smart Data Cache Injection (SDCI) Allocation Enforcement",
+                    info.has_sdciae(),
+                ),
+            ],
+        );
+        if let Some(info) = info.get_l3_memory_bandwidth_enforcement_info() {
+            print_title(
+                &skin,
+                "L3 Memory Bandwidth Enforcement Information (0x8000_0020/1):",
+            );
+            table2(
+                &skin,
+                &[
+                    RowGen::tuple("Bandwidth Length", info.bandwidth_length()),
+                    RowGen::tuple("COS Number", info.cos_max()),
+                ],
+            );
+        }
+        if let Some(info) = info.get_l3_slow_memory_bandwidth_enforcement_info() {
+            print_title(
+                &skin,
+                "L3 Slow Memory Bandwidth Enforcement Information (0x8000_0020/2):",
+            );
+            table2(
+                &skin,
+                &[
+                    RowGen::tuple("Bandwidth Length", info.bandwidth_length()),
+                    RowGen::tuple("COS Number", info.cos_max()),
+                ],
+            );
+        }
+        if let Some(info) = info.get_bandwidth_monitoring_event_counters_info() {
+            print_title(
+                &skin,
+                "Bandwidth Monitoring Event Counters Information (0x8000_0020/3):",
+            );
+            table2(
+                &skin,
+                &[
+                    RowGen::tuple(
+                        "Number of configurable bandwidth events",
+                        info.number_events(),
+                    ),
+                    RowGen::tuple(
+                        "Reads to local DRAM memory",
+                        info.has_l3_cache_lcl_bw_fill_mon(),
+                    ),
+                    RowGen::tuple(
+                        "Reads to remote DRAM memory",
+                        info.has_l3_cache_rmt_bw_fill_mon(),
+                    ),
+                    RowGen::tuple(
+                        "Non-temporal writes to local memory",
+                        info.has_l3_cache_lcl_bw_nt_wr_mon(),
+                    ),
+                    RowGen::tuple(
+                        "Non-temporal writes to remote memory",
+                        info.has_l3_cache_rmt_bw_nt_wr_mon(),
+                    ),
+                    RowGen::tuple(
+                        "Reads to local memory identified as 'Slow Memory'",
+                        info.has_l3_cache_lcl_slow_bw_fill_mon(),
+                    ),
+                    RowGen::tuple(
+                        "Reads to remote memory identified as 'Slow Memory'",
+                        info.has_l3_cache_rmt_slow_bw_fill_mon(),
+                    ),
+                    RowGen::tuple(
+                        "Dirty victim writes to all types of memory”.",
+                        info.has_l3_cache_vic_mon(),
+                    ),
+                ],
+            );
+        }
+        if let Some(info) = info.get_assignable_bandwidth_monitoring_counters_info() {
+            print_title(
+                &skin,
+                "Assignable Bandwidth Monitoring Counters Information (0x8000_0020/5):",
+            );
+            table2(
+                &skin,
+                &[
+                    RowGen::tuple(
+                        "Indicates that QM_CTR bit 61 is an overflow bit",
+                        info.has_overflow_bit(),
+                    ),
+                    RowGen::tuple(
+                        "QM_CTR counter width, offset from 24 bits",
+                        info.counter_size(),
+                    ),
+                    RowGen::tuple("Maximum supported ABMC counter ID", info.max_abmc()),
+                    RowGen::tuple(
+                        "Bandwidth counters can be configured",
+                        info.has_select_cos(),
+                    ),
+                ],
+            );
+        }
+    }
+
+    if let Some(info) = cpuid.get_extended_feature_identification_2() {
+        print_title(&skin, "Extended Feature Identification (0x8000_0021):");
+        table2(
+            &skin,
+            &[
+                RowGen::tuple("Processor ignores nested data breakpoints", info.has_no_nested_data_bp()),
+                RowGen::tuple("LFENCE is always dispatch serializing", info.has_lfence_always_serializing()),
+                RowGen::tuple("SMM paging configuration lock supported", info.has_smm_pg_cfg_lock()),
+                RowGen::tuple("Null segment selector loads also clear the destination segment register base and limit", info.has_null_select_clears_base()),
+                RowGen::tuple("Upper Address Ignore is supported", info.has_upper_address_ignore()),
+                RowGen::tuple("Automatic IBRS", info.has_automatic_ibrs()),
+                RowGen::tuple("SMM_CTL MSR (C001_0116h) is not supporte", info.has_no_smm_ctl_msr()),
+                RowGen::tuple("Prefetch control MSR supporte", info.has_prefetch_ctl_msr()),
+                RowGen::tuple("CPUID disable for non-privileged softwar", info.has_cpuid_user_dis()),
+                RowGen::tuple("The size of the Microcode patch in 16-byte multiples", info.microcode_patch_size()),
+            ],
+        );
+    }
+
+    if let Some(info) = cpuid.get_extended_performance_monitoring_and_debug() {
+        print_title(
+            &skin,
+            "Extended Performance Monitoring and Debug (0x8000_0022):",
+        );
+        table2(
+            &skin,
+            &[
+                RowGen::tuple(
+                    "Performance Monitoring Version 2 supported",
+                    info.has_perf_mon_v2(),
+                ),
+                RowGen::tuple("Last Branch Record Stack supported", info.has_lbr_stack()),
+                RowGen::tuple("LbrAndPmcFreeze", info.has_lbr_and_pmc_freeze()),
+                RowGen::tuple(
+                    "Number of Core Performance Counters",
+                    info.num_perf_ctr_core(),
+                ),
+                RowGen::tuple(
+                    "Number of Last Branch Record Stack entries",
+                    info.num_lbr_stack_size(),
+                ),
+                RowGen::tuple(
+                    "Number of Northbridge Performance Monitor Counters",
+                    info.num_perf_ctr_nb(),
+                ),
+            ],
+        );
+    }
+
+    if let Some(info) = cpuid.get_multi_key_encrypted_memory_capabilities() {
+        print_title(
+            &skin,
+            "Multi-Key Encrypted Memory Capabilities (0x8000_0023):",
+        );
+        table2(
+            &skin,
+            &[
+                RowGen::tuple(
+                    "Secure Host Multi-Key Memory (MEM-HMK) Encryption Mode Supported",
+                    info.has_mem_hmk(),
+                ),
+                RowGen::tuple("MaxMemHmkEncrKeyID", info.max_mem_hmk_encr_key_id()),
+            ],
+        );
+    }
+
+    if let Some(info) = cpuid.get_extended_cpu_topology() {
+        for (level, info) in info.enumerate() {
+            print_title(
+                &skin,
+                &format!("Extended CPU Topology (0x8000_0026/{level}):"),
+            );
+            table2(
+                &skin,
+                &[
+                    RowGen::tuple("Mask Width", info.mask_width()),
+                    RowGen::tuple(
+                        "Efficiency Ranking Available",
+                        info.has_efficiency_ranking_available(),
+                    ),
+                    RowGen::tuple("Heterogeneous Cores", info.has_heterogeneous_cores()),
+                    RowGen::tuple("Asymmetric Topology", info.has_asymmetric_topology()),
+                    RowGen::tuple(
+                        "Number of logical processors at the current hierarchy level",
+                        info.num_logical_processors(),
+                    ),
+                    RowGen::tuple(
+                        "Static efficiency ranking between cores of a specific core type",
+                        info.pwr_efficiency_ranking(),
+                    ),
+                    RowGen::tuple("Native Mode Id", info.native_mode_id()),
+                    RowGen::tuple("Core Type", info.core_type()),
+                    RowGen::tuple("Level Type", info.level_type().to_string()),
+                    RowGen::tuple(
+                        "Extended APIC ID of the logical processo",
+                        info.extended_apic_id(),
+                    ),
+                ],
+            );
+        }
+    }
 }

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1,5 +1,5 @@
+use crate::{CpuIdReader, CpuIdResult, CpuIdWriter};
 use std::collections::HashMap;
-use crate::{CpuIdResult, CpuIdReader, CpuIdWriter};
 
 #[derive(Clone)]
 enum LeafOrSubleaves {
@@ -73,7 +73,11 @@ impl Iterator for CpuIdDumpIter {
             };
 
             self.leaf = *first_key;
-            let entry = self.dump.leaves.remove(&self.leaf).expect("leaf is present");
+            let entry = self
+                .dump
+                .leaves
+                .remove(&self.leaf)
+                .expect("leaf is present");
             match entry {
                 LeafOrSubleaves::Leaf(regs) => {
                     return Some((self.leaf, None, regs));

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1,0 +1,219 @@
+use std::collections::HashMap;
+use crate::{CpuIdResult, CpuIdReader, CpuIdWriter};
+
+#[derive(Clone)]
+enum LeafOrSubleaves {
+    Leaf(CpuIdResult),
+    Subleaf(HashMap<u32, CpuIdResult>),
+}
+
+// TODO: Clone is necessary because CpuIdReader wants it (for leaves with more complex subleaf
+// structures, like the extended topology info leaf)
+//
+// This implies that there's a full clone of the dump held on for those leaf-specific views, which
+// is unfortunate! It's also not yet really clear how to assemble those more complex leaves for
+// writer purposes.
+#[derive(Clone)]
+pub struct CpuIdDump {
+    leaves: HashMap<u32, LeafOrSubleaves>,
+}
+
+impl CpuIdDump {
+    // TODO: probably should just take vendor in the initial constructor here
+    // (that also lets this pick the right leaf/subleaf fallback behavior from the get-go)
+    pub fn new() -> Self {
+        Self {
+            leaves: HashMap::new(),
+        }
+    }
+}
+
+const DEFAULT_LEAF: CpuIdResult = CpuIdResult {
+    eax: 0,
+    ebx: 0,
+    ecx: 0,
+    edx: 0,
+};
+
+impl CpuIdWriter for CpuIdDump {
+    fn set_leaf(&mut self, leaf: u32, mut bits: Option<CpuIdResult>) {
+        // Many bits in 8000_0001h EDX, if present, mirror leaf 1h EDX. Maintain that before
+        // storing the bits.
+        if let Some(bits) = bits.as_mut() {
+            const MIRROR_MASK: u32 = 0b0000_0001_1000_0011_1111_0011_1111_1111;
+
+            let update = if leaf == 0x0000_0001 {
+                // We're updating leaf 1h, so go fix up leaf 8000_0001h (if present)
+                match self.leaves.get_mut(&0x8000_0001) {
+                    Some(LeafOrSubleaves::Leaf(ext_info)) => {
+                        ext_info.edx &= !MIRROR_MASK;
+                        ext_info.edx |= bits.edx & MIRROR_MASK;
+                    }
+                    Some(_) => {
+                        panic!("extended feature information leaf (8000_0001h) had subleaves?");
+                    }
+                    None => {
+                        // No leaf 8000_0001h to mirror to (yet?)
+                    }
+                }
+            } else if leaf == 0x8000_0001 {
+                match self.leaves.get(&0x0000_0001) {
+                    Some(LeafOrSubleaves::Leaf(prior_bits)) => {
+                        bits.edx &= !MIRROR_MASK;
+                        bits.edx |= prior_bits.edx & MIRROR_MASK;
+                    }
+                    Some(_) => {
+                        panic!("feature information leaf (01h) had subleaves?");
+                    }
+                    None => {
+                        // No leaf 1h to shadow (yet?)
+                    }
+                }
+            };
+        }
+
+        if let Some(bits) = bits {
+            self.leaves.insert(leaf, LeafOrSubleaves::Leaf(bits));
+        } else {
+            self.leaves.remove(&leaf);
+        }
+
+        self.update_max_leaves();
+    }
+    fn set_subleaf(&mut self, leaf: u32, subleaf: u32, bits: Option<CpuIdResult>) {
+        if let Some(bits) = bits {
+            match self
+                .leaves
+                .entry(leaf)
+                .or_insert(LeafOrSubleaves::Subleaf(HashMap::new()))
+            {
+                LeafOrSubleaves::Leaf(_) => {
+                    panic!("adding a subleaf where there's a leaf. no");
+                }
+                LeafOrSubleaves::Subleaf(leaves) => {
+                    leaves.insert(subleaf, bits);
+                }
+            }
+        } else {
+            self.leaves.get_mut(&leaf).map(|ent| {
+                if let LeafOrSubleaves::Subleaf(leaves) = ent {
+                    leaves.remove(&subleaf);
+                } else {
+                    panic!("removing a subleaf when there's a leaf. no");
+                }
+            });
+        }
+
+        self.update_max_leaves();
+    }
+}
+
+impl CpuIdDump {
+    fn update_max_leaves(&mut self) {
+        let mut max_standard = None;
+        let mut max_hv = None;
+        let mut max_extended = None;
+
+        for (idx, k) in self.leaves.keys().enumerate() {
+            let k = *k;
+            if k < 0x40000000 {
+                max_standard = Some(match max_standard {
+                    None => k,
+                    Some(prev) => core::cmp::max(k, prev),
+                });
+            } else if k < 0x80000000 {
+                max_hv = Some(match max_hv {
+                    None => k,
+                    Some(prev) => core::cmp::max(k, prev),
+                });
+            } else if k < 0xc0000000 {
+                max_extended = Some(match max_extended {
+                    None => k,
+                    Some(prev) => core::cmp::max(k, prev),
+                });
+            }
+        }
+
+        if let Some(eax) = max_standard {
+            match self
+                .leaves
+                .entry(0)
+                .or_insert(LeafOrSubleaves::Leaf(CpuIdResult::empty()))
+            {
+                LeafOrSubleaves::Leaf(leaf) => {
+                    leaf.eax = eax;
+                }
+                _ => {
+                    panic!("cannot update leaf 1.EAX: leaf has subleaves?");
+                }
+            }
+        }
+
+        if let Some(eax) = max_hv {
+            match self
+                .leaves
+                .entry(0x40000000)
+                .or_insert(LeafOrSubleaves::Leaf(CpuIdResult::empty()))
+            {
+                LeafOrSubleaves::Leaf(leaf) => {
+                    leaf.eax = eax;
+                }
+                _ => {
+                    panic!("cannot update leaf 0x40000000.EAX: leaf has subleaves?");
+                }
+            }
+        }
+
+        if let Some(eax) = max_extended {
+            match self
+                .leaves
+                .entry(0x80000000)
+                .or_insert(LeafOrSubleaves::Leaf(CpuIdResult::empty()))
+            {
+                LeafOrSubleaves::Leaf(leaf) => {
+                    leaf.eax = eax;
+                }
+                _ => {
+                    panic!("cannot update leaf 0x80000000.EAX: leaf has subleaves?");
+                }
+            }
+        }
+    }
+}
+
+impl CpuIdReader for CpuIdDump {
+    fn cpuid1(&self, leaf: u32) -> CpuIdResult {
+        match self.leaves.get(&leaf) {
+            Some(LeafOrSubleaves::Leaf(res)) => *res,
+            Some(LeafOrSubleaves::Subleaf(subleaves)) => {
+                *subleaves.get(&0).unwrap_or_else(|| {
+                    // TODO: vendor-specific fallback behavior
+                    &DEFAULT_LEAF
+                })
+            }
+            None => {
+                // TODO: more vendor-specific fallback behavior
+                DEFAULT_LEAF
+            }
+        }
+    }
+
+    fn cpuid2(&self, leaf: u32, subleaf: u32) -> CpuIdResult {
+        match self.leaves.get(&leaf) {
+            Some(LeafOrSubleaves::Leaf(res)) => {
+                // TODO: vendor-specific fallback behavior
+                DEFAULT_LEAF
+            }
+            Some(LeafOrSubleaves::Subleaf(subleaves)) => {
+                *subleaves.get(&subleaf).unwrap_or_else(|| {
+                    // TODO: vendor-specific fallback behavior
+                    &DEFAULT_LEAF
+                })
+            }
+            None => {
+                // TODO: more vendor-specific fallback behavior
+                DEFAULT_LEAF
+            }
+        }
+    }
+}

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -100,7 +100,7 @@ impl CpuIdWriter for CpuIdDump {
         if let Some(bits) = bits.as_mut() {
             const MIRROR_MASK: u32 = 0b0000_0001_1000_0011_1111_0011_1111_1111;
 
-            let update = if leaf == 0x0000_0001 {
+            if leaf == 0x0000_0001 {
                 // We're updating leaf 1h, so go fix up leaf 8000_0001h (if present)
                 match self.leaves.get_mut(&0x8000_0001) {
                     Some(LeafOrSubleaves::Leaf(ext_info)) => {
@@ -172,7 +172,7 @@ impl CpuIdDump {
         let mut max_hv = None;
         let mut max_extended = None;
 
-        for (idx, k) in self.leaves.keys().enumerate() {
+        for k in self.leaves.keys() {
             let k = *k;
             if k < 0x40000000 {
                 max_standard = Some(match max_standard {
@@ -258,7 +258,7 @@ impl CpuIdReader for CpuIdDump {
 
     fn cpuid2(&self, leaf: u32, subleaf: u32) -> CpuIdResult {
         match self.leaves.get(&leaf) {
-            Some(LeafOrSubleaves::Leaf(res)) => {
+            Some(LeafOrSubleaves::Leaf(_res)) => {
                 // TODO: vendor-specific fallback behavior
                 DEFAULT_LEAF
             }

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -1887,6 +1887,15 @@ pub struct SvmFeatures {
 }
 
 impl SvmFeatures {
+    pub fn empty() -> Self {
+        Self {
+            eax: 0,
+            ebx: 0,
+            _ecx: 0,
+            edx: SvmFeaturesEdx::from_bits_truncate(0),
+        }
+    }
+
     pub(crate) fn new(data: CpuIdResult) -> Self {
         Self {
             eax: data.eax,

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -5,7 +5,10 @@ use core::mem::size_of;
 use core::slice;
 use core::str;
 
-use crate::{get_bits, set_bits, CpuIdResult, Vendor};
+use crate::{
+    get_bits, set_bits, CpuIdReader, CpuIdResult, Vendor, EAX_EXTENDED_CPU_TOPOLOGY,
+    EAX_PQOS_EXTENDED_FEATURES,
+};
 
 /// Extended Processor and Processor Feature Identifiers (LEAF=0x8000_0001)
 ///
@@ -2215,5 +2218,696 @@ bitflags! {
         const DBGSWP = 1 << 14;
         const PREVHOSTIBS = 1 << 15;
         const VTE = 1 << 16;
+    }
+}
+
+/// Platform Quality of Service Information (LEAF=0x8000_0020).
+///
+/// # Platforms
+/// ✅ AMD ❌ Intel
+#[derive(PartialEq, Eq)]
+pub struct PqosExtendedFeatureInfo<R: CpuIdReader> {
+    source: R,
+    _eax: u32,
+    ebx: PqosExtendedFeatureInfoEbx,
+    _ecx: u32,
+    _edx: u32,
+}
+
+impl<R: CpuIdReader> PqosExtendedFeatureInfo<R> {
+    pub(crate) fn new(source: R) -> Self {
+        let data = source.cpuid2(EAX_PQOS_EXTENDED_FEATURES, 0);
+        Self {
+            source,
+            _eax: data.eax,
+            ebx: PqosExtendedFeatureInfoEbx::from_bits_truncate(data.ebx),
+            _ecx: data.ecx,
+            _edx: data.edx,
+        }
+    }
+
+    /// Memory Bandwidth Enforcement is supported if set.
+    pub fn has_l3mbe(&self) -> bool {
+        self.ebx.contains(PqosExtendedFeatureInfoEbx::L3MBE)
+    }
+
+    /// Slow Memory Bandwidth Enforcement is supported if set.
+    pub fn has_l3smbe(&self) -> bool {
+        self.ebx.contains(PqosExtendedFeatureInfoEbx::L3SMBE)
+    }
+
+    /// Bandwidth Monitoring Event Configuration is supported if set.
+    pub fn has_bmec(&self) -> bool {
+        self.ebx.contains(PqosExtendedFeatureInfoEbx::BMEC)
+    }
+
+    /// L3 Range Reservations. See “L3 Range Reservation” in APM
+    /// Volume 2 is supported if set.
+    pub fn has_l3rr(&self) -> bool {
+        self.ebx.contains(PqosExtendedFeatureInfoEbx::L3RR)
+    }
+
+    /// Assignable Bandwidth Monitoring Counters is supported if set.
+    pub fn has_abmc(&self) -> bool {
+        self.ebx.contains(PqosExtendedFeatureInfoEbx::ABMC)
+    }
+
+    /// Smart Data Cache Injection (SDCI) Allocation Enforcement is supported if set.
+    pub fn has_sdciae(&self) -> bool {
+        self.ebx.contains(PqosExtendedFeatureInfoEbx::SDCIAE)
+    }
+
+    /// Get L3 Memory Bandwidth Enforcement Information
+    pub fn get_l3_memory_bandwidth_enforcement_info(
+        &self,
+    ) -> Option<L3MemoryBandwidthEnforcementInformation> {
+        if self.has_l3mbe() {
+            Some(L3MemoryBandwidthEnforcementInformation::new(
+                self.source.cpuid2(EAX_PQOS_EXTENDED_FEATURES, 1),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Get L3 Slow Memory Bandwidth Enforcement Information
+    pub fn get_l3_slow_memory_bandwidth_enforcement_info(
+        &self,
+    ) -> Option<L3MemoryBandwidthEnforcementInformation> {
+        if self.has_l3smbe() {
+            Some(L3MemoryBandwidthEnforcementInformation::new(
+                self.source.cpuid2(EAX_PQOS_EXTENDED_FEATURES, 2),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Get Bandwidth Monitoring Event Counters Information
+    pub fn get_bandwidth_monitoring_event_counters_info(
+        &self,
+    ) -> Option<BandwidthMonitoringEventCounters> {
+        if self.has_bmec() {
+            Some(BandwidthMonitoringEventCounters::new(
+                self.source.cpuid2(EAX_PQOS_EXTENDED_FEATURES, 3),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Get Bandwidth Monitoring Event Counters Information
+    pub fn get_assignable_bandwidth_monitoring_counters_info(
+        &self,
+    ) -> Option<AssignableBandwidthMonitoringCounterInfo> {
+        if self.has_abmc() {
+            Some(AssignableBandwidthMonitoringCounterInfo::new(
+                self.source.cpuid2(EAX_PQOS_EXTENDED_FEATURES, 5),
+            ))
+        } else {
+            None
+        }
+    }
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct PqosExtendedFeatureInfoEbx: u32 {
+        const L3MBE = 1 << 1;
+        const L3SMBE = 1 << 2;
+        const BMEC = 1 << 3;
+        const L3RR = 1 << 4;
+        const ABMC = 1 << 5;
+        const SDCIAE = 1 << 6;
+    }
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct PqosExtendedFeatureInfoEbx5: u32 {
+        const SELECT_COS = 1 << 0;
+    }
+}
+
+impl<R: CpuIdReader> Debug for PqosExtendedFeatureInfo<R> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PqosExtendedFeatureInfo")
+            .field("has_l3mbe", &self.has_l3mbe())
+            .field("has_l3smbe", &self.has_l3smbe())
+            .field("has_bmec", &self.has_bmec())
+            .field("has_l3rr", &self.has_l3rr())
+            .field("has_abmc", &self.has_abmc())
+            .field("has_sdciae", &self.has_sdciae())
+            .finish()
+    }
+}
+
+/// L3 Memory Bandwidth Enforcement Information (LEAF=0x8000_0020_x1 and x2).
+///
+/// # Platforms
+/// ✅ AMD ❌ Intel
+#[derive(PartialEq, Eq, Debug)]
+pub struct L3MemoryBandwidthEnforcementInformation {
+    eax: u32,
+    _ebx: u32,
+    _ecx: u32,
+    edx: u32,
+}
+
+impl L3MemoryBandwidthEnforcementInformation {
+    pub(crate) fn new(data: CpuIdResult) -> Self {
+        Self {
+            eax: data.eax,
+            _ebx: data.ebx,
+            _ecx: data.ecx,
+            edx: data.edx,
+        }
+    }
+
+    /// Identifies the size of the bandwidth specifier field in the
+    /// L3QOS_BW_Control_n MSRs
+    pub fn bandwidth_length(&self) -> u32 {
+        self.eax
+    }
+
+    /// Maximum COS number supported by the L3MBE feature
+    pub fn cos_max(&self) -> u32 {
+        self.edx
+    }
+}
+
+/// Bandwidth Monitoring Event Counters Information (LEAF=0x8000_0020_x3).
+///
+/// # Platforms
+/// ✅ AMD ❌ Intel
+#[derive(PartialEq, Eq, Debug)]
+pub struct BandwidthMonitoringEventCounters {
+    _eax: u32,
+    ebx: u32,
+    ecx: BandwidthMonitoringEventCountersEcx,
+    _edx: u32,
+}
+
+impl BandwidthMonitoringEventCounters {
+    pub(crate) fn new(data: CpuIdResult) -> Self {
+        Self {
+            _eax: data.eax,
+            ebx: data.ebx,
+            ecx: BandwidthMonitoringEventCountersEcx::from_bits_truncate(data.ecx),
+            _edx: data.edx,
+        }
+    }
+
+    /// Get Number of configurable bandwidth events
+    pub fn number_events(&self) -> u32 {
+        get_bits(self.ebx, 0, 7)
+    }
+
+    /// Reads to local DRAM memory is supported if set.
+    pub fn has_l3_cache_lcl_bw_fill_mon(&self) -> bool {
+        self.ecx
+            .contains(BandwidthMonitoringEventCountersEcx::L3_CACHE_LCL_BW_FILL_MON)
+    }
+
+    /// Reads to remote DRAM memory is supported if set.
+    pub fn has_l3_cache_rmt_bw_fill_mon(&self) -> bool {
+        self.ecx
+            .contains(BandwidthMonitoringEventCountersEcx::L3_CACHE_RMT_BW_FILL_MON)
+    }
+
+    /// Non-temporal writes to local memory is supported if set.
+    pub fn has_l3_cache_lcl_bw_nt_wr_mon(&self) -> bool {
+        self.ecx
+            .contains(BandwidthMonitoringEventCountersEcx::L3_CACHE_LCL_BW_NT_WR_MON)
+    }
+
+    /// Non-temporal writes to remote memory is supported if set.
+    pub fn has_l3_cache_rmt_bw_nt_wr_mon(&self) -> bool {
+        self.ecx
+            .contains(BandwidthMonitoringEventCountersEcx::L3_CACHE_RMT_BW_NT_WR_MON)
+    }
+
+    /// Reads to local memory identified as “Slow Memory” is supported if set.
+    pub fn has_l3_cache_lcl_slow_bw_fill_mon(&self) -> bool {
+        self.ecx
+            .contains(BandwidthMonitoringEventCountersEcx::L3_CACHE_LCL_SLOW_BW_FILL_MON)
+    }
+
+    /// Reads to remote memory identified as “Slow Memory” is supported if set.
+    pub fn has_l3_cache_rmt_slow_bw_fill_mon(&self) -> bool {
+        self.ecx
+            .contains(BandwidthMonitoringEventCountersEcx::L3_CACHE_RMT_SLOW_BW_FILL_MON)
+    }
+
+    /// Dirty victim writes to all types of memory is supported if set.
+    pub fn has_l3_cache_vic_mon(&self) -> bool {
+        self.ecx
+            .contains(BandwidthMonitoringEventCountersEcx::L3_CACHE_VIC_MON)
+    }
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct BandwidthMonitoringEventCountersEcx: u32 {
+        const L3_CACHE_LCL_BW_FILL_MON = 1 << 0;
+        const L3_CACHE_RMT_BW_FILL_MON = 1 << 1;
+        const L3_CACHE_LCL_BW_NT_WR_MON = 1 << 2;
+        const L3_CACHE_RMT_BW_NT_WR_MON = 1 << 3;
+        const L3_CACHE_LCL_SLOW_BW_FILL_MON = 1 << 4;
+        const L3_CACHE_RMT_SLOW_BW_FILL_MON = 1 << 5;
+        const L3_CACHE_VIC_MON = 1 << 6;
+    }
+}
+
+/// L3 Memory Bandwidth Enforcement Information (LEAF=0x8000_0020_x5).
+///
+/// # Platforms
+/// ✅ AMD ❌ Intel
+#[derive(PartialEq, Eq, Debug)]
+pub struct AssignableBandwidthMonitoringCounterInfo {
+    eax: u32,
+    ebx: u32,
+    ecx: u32,
+    _edx: u32,
+}
+
+impl AssignableBandwidthMonitoringCounterInfo {
+    pub(crate) fn new(data: CpuIdResult) -> Self {
+        Self {
+            eax: data.eax,
+            ebx: data.ebx,
+            ecx: data.ecx,
+            _edx: data.edx,
+        }
+    }
+
+    /// Get QM_CTR counter width, offset from 24 bits
+    pub fn counter_size(&self) -> u8 {
+        get_bits(self.eax, 0, 7) as u8
+    }
+
+    /// Indicates that QM_CTR bit 61 is an overflow bit if set
+    pub fn has_overflow_bit(&self) -> bool {
+        (self.eax & (1 << 8)) > 0
+    }
+
+    /// Get Maximum supported ABMC counter ID
+    pub fn max_abmc(&self) -> u16 {
+        get_bits(self.ebx, 0, 15) as u16
+    }
+
+    ///  Bandwidth counters can be configured to measure
+    /// bandwidth consumed by a COS instead of an RMID if set
+    pub fn has_select_cos(&self) -> bool {
+        (self.ecx & 1) > 0
+    }
+}
+
+/// Extended Feature Identification 2 (LEAF=0x8000_0021).
+///
+/// # Platforms
+/// ✅ AMD ❌ Intel
+#[derive(PartialEq, Eq, Debug)]
+pub struct ExtendedFeatureIdentification2 {
+    eax: ExtendedFeatureIdentification2Eax,
+    ebx: u32,
+    _ecx: u32,
+    _edx: u32,
+}
+
+impl ExtendedFeatureIdentification2 {
+    pub(crate) fn new(data: CpuIdResult) -> Self {
+        Self {
+            eax: ExtendedFeatureIdentification2Eax::from_bits_truncate(data.eax),
+            ebx: data.ebx,
+            _ecx: data.ecx,
+            _edx: data.edx,
+        }
+    }
+
+    /// Processor ignores nested data breakpoints if set
+    pub fn has_no_nested_data_bp(&self) -> bool {
+        self.eax
+            .contains(ExtendedFeatureIdentification2Eax::NO_NESTED_DATA_BP)
+    }
+
+    /// LFENCE is always dispatch serializing if set
+    pub fn has_lfence_always_serializing(&self) -> bool {
+        self.eax
+            .contains(ExtendedFeatureIdentification2Eax::LFENCE_ALWAYS_SERIALIZING)
+    }
+
+    /// SMM paging configuration lock supported if set
+    pub fn has_smm_pg_cfg_lock(&self) -> bool {
+        self.eax
+            .contains(ExtendedFeatureIdentification2Eax::SMM_PG_CFG_LOCK)
+    }
+
+    /// Null segment selector loads also clear the destination segment register
+    /// base and limit supported if set
+    pub fn has_null_select_clears_base(&self) -> bool {
+        self.eax
+            .contains(ExtendedFeatureIdentification2Eax::NULL_SELECT_CLEARS_BASE)
+    }
+
+    /// Upper Address Ignore is supported if set
+    pub fn has_upper_address_ignore(&self) -> bool {
+        self.eax
+            .contains(ExtendedFeatureIdentification2Eax::UPPER_ADDRESS_IGNORE)
+    }
+
+    /// Automatic IBRS if set
+    pub fn has_automatic_ibrs(&self) -> bool {
+        self.eax
+            .contains(ExtendedFeatureIdentification2Eax::AUTOMATIC_IBRS)
+    }
+
+    /// SMM_CTL MSR (C001_0116h) is not supported if set
+    pub fn has_no_smm_ctl_msr(&self) -> bool {
+        self.eax
+            .contains(ExtendedFeatureIdentification2Eax::NO_SMM_CTL_MSR)
+    }
+
+    /// Prefetch control MSR supported if set
+    pub fn has_prefetch_ctl_msr(&self) -> bool {
+        self.eax
+            .contains(ExtendedFeatureIdentification2Eax::PREFETCH_CTL_MSR)
+    }
+
+    /// CPUID disable for non-privileged software if set
+    pub fn has_cpuid_user_dis(&self) -> bool {
+        self.eax
+            .contains(ExtendedFeatureIdentification2Eax::CPUID_USER_DIS)
+    }
+
+    /// The size of the Microcode patch in 16-byte multiples. If 0, the size of the
+    /// patch is at most 5568 (15C0h) bytes.
+    pub fn microcode_patch_size(&self) -> u16 {
+        get_bits(self.ebx, 0, 11) as u16
+    }
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct ExtendedFeatureIdentification2Eax: u32 {
+        const NO_NESTED_DATA_BP = 1 << 0;
+        const LFENCE_ALWAYS_SERIALIZING = 1 << 2;
+        const SMM_PG_CFG_LOCK = 1 << 3;
+        const NULL_SELECT_CLEARS_BASE = 1 << 6;
+        const UPPER_ADDRESS_IGNORE = 1 << 7;
+        const AUTOMATIC_IBRS = 1 << 8;
+        const NO_SMM_CTL_MSR = 1 << 9;
+        const PREFETCH_CTL_MSR = 1 << 13;
+        const CPUID_USER_DIS = 1 << 17;
+    }
+}
+
+/// Extended Feature Identification 2 (LEAF=0x8000_0021).
+///
+/// # Platforms
+/// ✅ AMD ❌ Intel
+#[derive(PartialEq, Eq, Debug)]
+pub struct ExtendedPerformanceMonitoringDebug {
+    eax: ExtendedPerformanceMonitoringDebugEax,
+    ebx: u32,
+    _ecx: u32,
+    _edx: u32,
+}
+
+impl ExtendedPerformanceMonitoringDebug {
+    pub(crate) fn new(data: CpuIdResult) -> Self {
+        Self {
+            eax: ExtendedPerformanceMonitoringDebugEax::from_bits_truncate(data.eax),
+            ebx: data.ebx,
+            _ecx: data.ecx,
+            _edx: data.edx,
+        }
+    }
+
+    /// Performance Monitoring Version 2 supported if set
+    pub fn has_perf_mon_v2(&self) -> bool {
+        self.eax
+            .contains(ExtendedPerformanceMonitoringDebugEax::PERF_MON_V2)
+    }
+
+    /// Last Branch Record Stack supported if set
+    pub fn has_lbr_stack(&self) -> bool {
+        self.eax
+            .contains(ExtendedPerformanceMonitoringDebugEax::LBR_STACK)
+    }
+
+    /// Freezing Core Performance Counters and LBR Stack on Core
+    /// Performance Counter overflow supported if set
+    pub fn has_lbr_and_pmc_freeze(&self) -> bool {
+        self.eax
+            .contains(ExtendedPerformanceMonitoringDebugEax::LBR_AND_PMC_FREEZE)
+    }
+
+    /// Number of Core Performance Counters
+    pub fn num_perf_ctr_core(&self) -> u8 {
+        get_bits(self.ebx, 0, 3) as u8
+    }
+
+    /// Number of Last Branch Record Stack entries
+    pub fn num_lbr_stack_size(&self) -> u8 {
+        get_bits(self.ebx, 4, 9) as u8
+    }
+
+    /// Number of Northbridge Performance Monitor Counters
+    pub fn num_perf_ctr_nb(&self) -> u8 {
+        get_bits(self.ebx, 10, 15) as u8
+    }
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct ExtendedPerformanceMonitoringDebugEax: u32 {
+        const PERF_MON_V2 = 1 << 0;
+        const LBR_STACK = 1 << 1;
+        const LBR_AND_PMC_FREEZE = 1 << 2;
+    }
+}
+
+/// Extended Feature Identification 2 (LEAF=0x8000_0021).
+///
+/// # Platforms
+/// ✅ AMD ❌ Intel
+#[derive(PartialEq, Eq, Debug)]
+pub struct MultiKeyEncryptedMemoryCapabilities {
+    eax: MultiKeyEncryptedMemoryCapabilitiesEax,
+    ebx: u32,
+    _ecx: u32,
+    _edx: u32,
+}
+
+impl MultiKeyEncryptedMemoryCapabilities {
+    pub(crate) fn new(data: CpuIdResult) -> Self {
+        Self {
+            eax: MultiKeyEncryptedMemoryCapabilitiesEax::from_bits_truncate(data.eax),
+            ebx: data.ebx,
+            _ecx: data.ecx,
+            _edx: data.edx,
+        }
+    }
+
+    /// Secure Host Multi-Key Memory (MEM-HMK) Encryption Mode Supported if set
+    pub fn has_mem_hmk(&self) -> bool {
+        self.eax
+            .contains(MultiKeyEncryptedMemoryCapabilitiesEax::MEM_HMK)
+    }
+
+    /// Number of simultaneously available host encryption key IDs in MEM-HMK
+    /// encryption mode.
+    pub fn max_mem_hmk_encr_key_id(&self) -> u16 {
+        get_bits(self.ebx, 0, 15) as u16
+    }
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct MultiKeyEncryptedMemoryCapabilitiesEax: u32 {
+        const MEM_HMK = 1 << 0;
+    }
+}
+
+/// Extended CPU Topology (LEAF=0x8000_0026).
+///
+/// Iterates over the extended cpu topology in order to retrieve more information for logical
+/// processors, including asymmetric and heterogenous topology descriptions. Individual
+/// logical processors may report different values in systems with asynchronous and
+/// heterogeneous topologies
+///
+/// # Platforms
+/// ✅ AMD ❌ Intel
+#[derive(Clone)]
+pub struct ExtendedCpuTopologyIter<R: CpuIdReader> {
+    source: R,
+    level: u32,
+}
+
+impl<R: CpuIdReader> ExtendedCpuTopologyIter<R> {
+    pub fn new(source: R) -> Self {
+        Self { source, level: 0 }
+    }
+}
+
+/// Gives information about the current level in the cpu topology.
+#[derive(PartialEq, Eq, Debug)]
+pub struct ExtendedCpuTopologyLevel {
+    eax: u32,
+    ebx: u32,
+    ecx: u32,
+    edx: u32,
+}
+
+impl ExtendedCpuTopologyLevel {
+    pub(crate) fn new(data: CpuIdResult) -> Self {
+        Self {
+            eax: data.eax,
+            ebx: data.ebx,
+            ecx: data.ecx,
+            edx: data.edx,
+        }
+    }
+
+    /// Number of bits to shift Extended APIC ID right to get a unique topology ID
+    /// of the current hierarchy level.
+    pub fn mask_width(&self) -> u8 {
+        get_bits(self.eax, 0, 4) as u8
+    }
+
+    /// Set to 1 if processor power efficiency ranking (PwrEfficiencyRanking) is
+    /// available and varies between cores. Only valid for LevelType = 1h (Core).
+    pub fn has_efficiency_ranking_available(&self) -> bool {
+        self.eax & (1 << 29) > 0
+    }
+
+    /// Set to 1 if all components at the current hierarchy level do not consist of
+    /// the cores that report the same core type (CoreType).
+    pub fn has_heterogeneous_cores(&self) -> bool {
+        self.eax & (1 << 30) > 0
+    }
+
+    /// Set to 1 if all components at the current hierarchy level do not report the
+    /// same number of logical processors (NumLogProc).
+    pub fn has_asymmetric_topology(&self) -> bool {
+        self.eax & (1 << 31) > 0
+    }
+
+    /// Number of logical processors at the current hierarchy level
+    pub fn num_logical_processors(&self) -> u16 {
+        get_bits(self.ebx, 0, 15) as u16
+    }
+
+    /// Reports a static efficiency ranking between cores of a specific core type,
+    /// where a lower value indicates comparatively lower power consumption
+    /// and lower performance. Only valid for LevelType = 1h (Core)
+    pub fn pwr_efficiency_ranking(&self) -> u8 {
+        get_bits(self.ebx, 16, 23) as u8
+    }
+
+    /// Reports a value that may be used to further differentiate implementation
+    /// specific features. Native mode ID is used in conjunction with the family,
+    /// model, and stepping identifiers. Refer to the Processor Programming
+    /// Reference Manual applicable to your product for a list of Native Mode
+    /// IDs. Only valid for LevelType = 1h (Core)
+    pub fn native_mode_id(&self) -> u8 {
+        get_bits(self.ebx, 24, 27) as u8
+    }
+
+    /// Reports a value that may be used to distinguish between cores with
+    /// different architectural and microarchitectural properties (for example,
+    /// cores with different performance or power characteristics). Refer to the
+    /// Processor Programming Reference Manual applicable to your product for
+    /// a list of the available core types. Only valid for LevelType = 1h (Core)
+    pub fn core_type(&self) -> u8 {
+        get_bits(self.ebx, 28, 31) as u8
+    }
+
+    /// Input ECX
+    pub fn input_ecx(&self) -> u8 {
+        get_bits(self.ecx, 0, 7) as u8
+    }
+
+    /// Encoded hierarchy level type
+    pub fn level_type(&self) -> HierarchyLevelType {
+        HierarchyLevelType::from(get_bits(self.ecx, 8, 15) as u8)
+    }
+
+    /// Extended APIC ID of the logical processor
+    pub fn extended_apic_id(&self) -> u32 {
+        self.edx
+    }
+}
+
+impl<R: CpuIdReader> Iterator for ExtendedCpuTopologyIter<R> {
+    type Item = ExtendedCpuTopologyLevel;
+
+    fn next(&mut self) -> Option<ExtendedCpuTopologyLevel> {
+        let res = self.source.cpuid2(EAX_EXTENDED_CPU_TOPOLOGY, self.level);
+        self.level += 1;
+
+        let ect = ExtendedCpuTopologyLevel::new(res);
+        if ect.level_type() == HierarchyLevelType::Reserved {
+            None
+        } else {
+            Some(ect)
+        }
+    }
+}
+
+#[repr(u8)]
+#[derive(PartialEq, Eq)]
+pub enum HierarchyLevelType {
+    Reserved = 0,
+    Core = 1,
+    Complex = 2,
+    Die = 3,
+    Socket = 4,
+    Unknown(u8),
+}
+
+impl From<u8> for HierarchyLevelType {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => Self::Reserved,
+            1 => Self::Core,
+            2 => Self::Complex,
+            3 => Self::Die,
+            4 => Self::Socket,
+            x => Self::Unknown(x),
+        }
+    }
+}
+
+impl Display for HierarchyLevelType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            HierarchyLevelType::Reserved => write!(f, "Reserved (0)"),
+            HierarchyLevelType::Core => write!(f, "Core (1)"),
+            HierarchyLevelType::Complex => write!(f, "Complex (2)"),
+            HierarchyLevelType::Die => write!(f, "DIE (3)"),
+            HierarchyLevelType::Socket => write!(f, "Socket (4)"),
+            HierarchyLevelType::Unknown(x) => write!(f, "Unknown ({x})"),
+        }
+    }
+}
+
+impl Debug for HierarchyLevelType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Reserved => write!(f, "Reserved"),
+            Self::Core => write!(f, "Core"),
+            Self::Complex => write!(f, "Complex"),
+            Self::Die => write!(f, "Die"),
+            Self::Socket => write!(f, "Socket"),
+            Self::Unknown(arg0) => f.debug_tuple("Unknown").field(arg0).finish(),
+        }
     }
 }

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -23,6 +23,16 @@ pub struct ExtendedProcessorFeatureIdentifiers {
 }
 
 impl ExtendedProcessorFeatureIdentifiers {
+    pub fn empty(vendor: Vendor) -> Self {
+        Self {
+            vendor,
+            eax: 0,
+            ebx: 0,
+            ecx: ExtendedFunctionInfoEcx::from_bits_truncate(0),
+            edx: ExtendedFunctionInfoEdx::from_bits_truncate(0),
+        }
+    }
+
     pub(crate) fn new(vendor: Vendor, data: CpuIdResult) -> Self {
         Self {
             vendor,
@@ -49,6 +59,11 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.eax
     }
 
+    pub fn set_extended_signature(&mut self, bits: u32) -> &mut Self {
+        self.eax = bits;
+        self
+    }
+
     /// Returns package type on AMD.
     ///
     /// Package type. If `(Family[7:0] >= 10h)`, this field is valid. If
@@ -58,6 +73,11 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// ✅ AMD ❌ Intel (reserved)
     pub fn pkg_type(&self) -> u32 {
         get_bits(self.ebx, 28, 31)
+    }
+
+    pub fn set_pkg_type(&mut self, bits: u32) -> &mut Self {
+        set_bits(&mut self.ebx, bits, 28, 31);
+        self
     }
 
     /// Returns brand ID on AMD.
@@ -71,12 +91,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         get_bits(self.ebx, 0, 15)
     }
 
+    pub fn set_brand_id(&mut self, bits: u32) -> &mut Self {
+        set_bits(&mut self.ebx, bits, 0, 15);
+        self
+    }
+
     /// Is LAHF/SAHF available in 64-bit mode?
     ///
     /// # Platforms
     /// ✅ AMD ✅ Intel
     pub fn has_lahf_sahf(&self) -> bool {
         self.ecx.contains(ExtendedFunctionInfoEcx::LAHF_SAHF)
+    }
+
+    pub fn set_lahf_sahf(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::LAHF_SAHF, bit);
+        self
     }
 
     /// Check support legacy cmp.
@@ -87,12 +117,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::CMP_LEGACY)
     }
 
+    pub fn set_cmp_legacy(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::CMP_LEGACY, bit);
+        self
+    }
+
     /// Secure virtual machine supported.
     ///
     /// # Platform
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_svm(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SVM)
+    }
+
+    pub fn set_svm(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::SVM, bit);
+        self
     }
 
     /// Extended APIC space.
@@ -106,12 +146,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::EXT_APIC_SPACE)
     }
 
+    pub fn set_ext_apic_space(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::EXT_APIC_SPACE, bit);
+        self
+    }
+
     /// LOCK MOV CR0 means MOV CR8. See “MOV(CRn)” in APM3.
     ///
     /// # Platform
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_alt_mov_cr8(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::ALTMOVCR8)
+    }
+
+    pub fn set_alt_mov_cr8(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::ALTMOVCR8, bit);
+        self
     }
 
     /// Is LZCNT available?
@@ -126,6 +176,11 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.ecx.contains(ExtendedFunctionInfoEcx::LZCNT)
     }
 
+    pub fn set_lzcnt(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::LZCNT, bit);
+        self
+    }
+
     /// XTRQ, INSERTQ, MOVNTSS, and MOVNTSD instruction support.
     ///
     /// See “EXTRQ”, “INSERTQ”,“MOVNTSS”, and “MOVNTSD” in APM4.
@@ -136,6 +191,11 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SSE4A)
     }
 
+    pub fn set_sse4a(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::SSE4A, bit);
+        self
+    }
+
     /// Misaligned SSE mode. See “Misaligned Access Support Added for SSE Instructions” in
     /// APM1.
     ///
@@ -143,6 +203,11 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_misaligned_sse_mode(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::MISALIGNSSE)
+    }
+
+    pub fn set_misaligned_sse_mode(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::MISALIGNSSE, bit);
+        self
     }
 
     /// Is PREFETCHW available?
@@ -156,12 +221,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.ecx.contains(ExtendedFunctionInfoEcx::PREFETCHW)
     }
 
+    pub fn set_prefetchw(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::PREFETCHW, bit);
+        self
+    }
+
     /// Indicates OS-visible workaround support
     ///
     /// # Platform
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_osvw(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::OSVW)
+    }
+
+    pub fn set_osvw(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::OSVW, bit);
+        self
     }
 
     /// Instruction based sampling.
@@ -172,12 +247,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::IBS)
     }
 
+    pub fn set_ibs(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::IBS, bit);
+        self
+    }
+
     /// Extended operation support.
     ///
     /// # Platform
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_xop(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::XOP)
+    }
+
+    pub fn set_xop(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::XOP, bit);
+        self
     }
 
     /// SKINIT and STGI are supported.
@@ -191,6 +276,11 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::SKINIT)
     }
 
+    pub fn set_skinit(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::SKINIT, bit);
+        self
+    }
+
     /// Watchdog timer support.
     ///
     /// Indicates support for MSRC001_0074.
@@ -201,12 +291,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::WDT)
     }
 
+    pub fn set_wdt(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::WDT, bit);
+        self
+    }
+
     /// Lightweight profiling support
     ///
     /// # Platform
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_lwp(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::LWP)
+    }
+
+    pub fn set_lwp(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::LWP, bit);
+        self
     }
 
     /// Four-operand FMA instruction support.
@@ -217,12 +317,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::FMA4)
     }
 
+    pub fn set_fma4(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::FMA4, bit);
+        self
+    }
+
     /// Trailing bit manipulation instruction support.
     ///
     /// # Platform
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_tbm(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::TBM)
+    }
+
+    pub fn set_tbm(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::TBM, bit);
+        self
     }
 
     /// Topology extensions support.
@@ -235,6 +345,11 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::TOPEXT)
     }
 
+    pub fn set_topology_extensions(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::TOPEXT, bit);
+        self
+    }
+
     /// Processor performance counter extensions support.
     ///
     /// Indicates support for `MSRC001_020[A,8,6,4,2,0]` and `MSRC001_020[B,9,7,5,3,1]`.
@@ -243,6 +358,11 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_perf_cntr_extensions(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFCTREXT)
+    }
+
+    pub fn set_perf_cntr_extensions(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::PERFCTREXT, bit);
+        self
     }
 
     /// NB performance counter extensions support.
@@ -255,6 +375,11 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFCTREXTNB)
     }
 
+    pub fn set_nb_perf_cntr_extensions(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::PERFCTREXTNB, bit);
+        self
+    }
+
     /// Data access breakpoint extension.
     ///
     /// Indicates support for `MSRC001_1027` and `MSRC001_101[B:9]`.
@@ -263,6 +388,11 @@ impl ExtendedProcessorFeatureIdentifiers {
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_data_access_bkpt_extension(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::DATABRKPEXT)
+    }
+
+    pub fn set_data_access_bkpt_extension(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::DATABRKPEXT, bit);
+        self
     }
 
     /// Performance time-stamp counter.
@@ -275,12 +405,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFTSC)
     }
 
+    pub fn set_perf_tsc(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::PERFTSC, bit);
+        self
+    }
+
     /// Support for L3 performance counter extension.
     ///
     /// # Platform
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_perf_cntr_llc_extensions(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::PERFCTREXTLLC)
+    }
+
+    pub fn set_perf_cntr_llc_extensions(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::PERFCTREXTLLC, bit);
+        self
     }
 
     /// Support for MWAITX and MONITORX instructions.
@@ -291,12 +431,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::MONITORX)
     }
 
+    pub fn set_monitorx_mwaitx(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::MONITORX, bit);
+        self
+    }
+
     /// Breakpoint Addressing masking extended to bit 31.
     ///
     /// # Platform
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_addr_mask_extension(&self) -> bool {
         self.vendor == Vendor::Amd && self.ecx.contains(ExtendedFunctionInfoEcx::ADDRMASKEXT)
+    }
+
+    pub fn set_addr_mask_extension(&mut self, bit: bool) -> &mut Self {
+        self.ecx.set(ExtendedFunctionInfoEcx::ADDRMASKEXT, bit);
+        self
     }
 
     /// Are fast system calls available.
@@ -307,12 +457,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.edx.contains(ExtendedFunctionInfoEdx::SYSCALL_SYSRET)
     }
 
+    pub fn set_syscall_sysret(&mut self, bit: bool) -> &mut Self {
+        self.edx.set(ExtendedFunctionInfoEdx::SYSCALL_SYSRET, bit);
+        self
+    }
+
     /// Is there support for execute disable bit.
     ///
     /// # Platforms
     /// ✅ AMD ✅ Intel
     pub fn has_execute_disable(&self) -> bool {
         self.edx.contains(ExtendedFunctionInfoEdx::EXECUTE_DISABLE)
+    }
+
+    pub fn set_execute_disable(&mut self, bit: bool) -> &mut Self {
+        self.edx.set(ExtendedFunctionInfoEdx::EXECUTE_DISABLE, bit);
+        self
     }
 
     /// AMD extensions to MMX instructions.
@@ -323,12 +483,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.edx.contains(ExtendedFunctionInfoEdx::MMXEXT)
     }
 
+    pub fn set_mmx_extensions(&mut self, bit: bool) -> &mut Self {
+        self.edx.set(ExtendedFunctionInfoEdx::MMXEXT, bit);
+        self
+    }
+
     /// FXSAVE and FXRSTOR instruction optimizations.
     ///
     /// # Platform
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_fast_fxsave_fxstor(&self) -> bool {
         self.vendor == Vendor::Amd && self.edx.contains(ExtendedFunctionInfoEdx::FFXSR)
+    }
+
+    pub fn set_fast_fxsave_fxstor(&mut self, bit: bool) -> &mut Self {
+        self.edx.set(ExtendedFunctionInfoEdx::FFXSR, bit);
+        self
     }
 
     /// Is there support for 1GiB pages.
@@ -339,12 +509,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.edx.contains(ExtendedFunctionInfoEdx::GIB_PAGES)
     }
 
+    pub fn set_1gib_pages(&mut self, bit: bool) -> &mut Self {
+        self.edx.set(ExtendedFunctionInfoEdx::GIB_PAGES, bit);
+        self
+    }
+
     /// Check support for rdtscp instruction.
     ///
     /// # Platforms
     /// ✅ AMD ✅ Intel
     pub fn has_rdtscp(&self) -> bool {
         self.edx.contains(ExtendedFunctionInfoEdx::RDTSCP)
+    }
+
+    pub fn set_rdtscp(&mut self, bit: bool) -> &mut Self {
+        self.edx.set(ExtendedFunctionInfoEdx::RDTSCP, bit);
+        self
     }
 
     /// Check support for 64-bit mode.
@@ -355,6 +535,11 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.edx.contains(ExtendedFunctionInfoEdx::I64BIT_MODE)
     }
 
+    pub fn set_64bit_mode(&mut self, bit: bool) -> &mut Self {
+        self.edx.set(ExtendedFunctionInfoEdx::I64BIT_MODE, bit);
+        self
+    }
+
     /// 3DNow AMD extensions.
     ///
     /// # Platform
@@ -363,12 +548,22 @@ impl ExtendedProcessorFeatureIdentifiers {
         self.vendor == Vendor::Amd && self.edx.contains(ExtendedFunctionInfoEdx::THREEDNOWEXT)
     }
 
+    pub fn set_amd_3dnow_extensions(&mut self, bit: bool) -> &mut Self {
+        self.edx.set(ExtendedFunctionInfoEdx::THREEDNOWEXT, bit);
+        self
+    }
+
     /// 3DNow extensions.
     ///
     /// # Platform
     /// ✅ AMD ❌ Intel (will return false)
     pub fn has_3dnow(&self) -> bool {
         self.vendor == Vendor::Amd && self.edx.contains(ExtendedFunctionInfoEdx::THREEDNOW)
+    }
+
+    pub fn set_3dnow(&mut self, bit: bool) -> &mut Self {
+        self.edx.set(ExtendedFunctionInfoEdx::THREEDNOW, bit);
+        self
     }
 }
 
@@ -1068,7 +1263,7 @@ impl ApmInfo {
     }
 
     pub fn set_succor(&mut self, bit: bool) -> &mut Self {
-        self.ebx.contains(RasCapabilities::SUCCOR);
+        self.ebx.set(RasCapabilities::SUCCOR, bit);
         self
     }
 
@@ -1083,7 +1278,7 @@ impl ApmInfo {
     }
 
     pub fn set_hwa(&mut self, bit: bool) -> &mut Self {
-        self.ebx.contains(RasCapabilities::HWA);
+        self.ebx.set(RasCapabilities::HWA, bit);
         self
     }
 
@@ -1112,7 +1307,7 @@ impl ApmInfo {
     }
 
     pub fn set_ts(&mut self, bit: bool) -> &mut Self {
-        self.edx.contains(ApmInfoEdx::TS);
+        self.edx.set(ApmInfoEdx::TS, bit);
         self
     }
 
@@ -1128,7 +1323,7 @@ impl ApmInfo {
     }
 
     pub fn set_freq_id_ctrl(&mut self, bit: bool) -> &mut Self {
-        self.edx.contains(ApmInfoEdx::FID);
+        self.edx.set(ApmInfoEdx::FID, bit);
         self
     }
 
@@ -1144,7 +1339,7 @@ impl ApmInfo {
     }
 
     pub fn set_volt_id_ctrl(&mut self, bit: bool) -> &mut Self {
-        self.edx.contains(ApmInfoEdx::VID);
+        self.edx.set(ApmInfoEdx::VID, bit);
         self
     }
 
@@ -1157,7 +1352,7 @@ impl ApmInfo {
     }
 
     pub fn set_thermtrip(&mut self, bit: bool) -> &mut Self {
-        self.edx.contains(ApmInfoEdx::TTP);
+        self.edx.set(ApmInfoEdx::TTP, bit);
         self
     }
 
@@ -1170,7 +1365,7 @@ impl ApmInfo {
     }
 
     pub fn set_tm(&mut self, bit: bool) -> &mut Self {
-        self.edx.contains(ApmInfoEdx::TM);
+        self.edx.set(ApmInfoEdx::TM, bit);
         self
     }
 
@@ -1183,7 +1378,7 @@ impl ApmInfo {
     }
 
     pub fn set_100mhz_steps(&mut self, bit: bool) -> &mut Self {
-        self.edx.contains(ApmInfoEdx::MHZSTEPS100);
+        self.edx.set(ApmInfoEdx::MHZSTEPS100, bit);
         self
     }
 
@@ -1199,7 +1394,7 @@ impl ApmInfo {
     }
 
     pub fn set_hw_pstate(&mut self, bit: bool) -> &mut Self {
-        self.edx.contains(ApmInfoEdx::HWPSTATE);
+        self.edx.set(ApmInfoEdx::HWPSTATE, bit);
         self
     }
 
@@ -1212,7 +1407,7 @@ impl ApmInfo {
     }
 
     pub fn set_invariant_tsc(&mut self, bit: bool) -> &mut Self {
-        self.edx.contains(ApmInfoEdx::INVTSC);
+        self.edx.set(ApmInfoEdx::INVTSC, bit);
         self
     }
 
@@ -1225,7 +1420,7 @@ impl ApmInfo {
     }
 
     pub fn set_cpb(&mut self, bit: bool) -> &mut Self {
-        self.edx.contains(ApmInfoEdx::CPB);
+        self.edx.set(ApmInfoEdx::CPB, bit);
         self
     }
 
@@ -1242,7 +1437,7 @@ impl ApmInfo {
     }
 
     pub fn set_ro_effective_freq_iface(&mut self, bit: bool) -> &mut Self {
-        self.edx.contains(ApmInfoEdx::EFFFREQRO);
+        self.edx.set(ApmInfoEdx::EFFFREQRO, bit);
         self
     }
 
@@ -1258,7 +1453,7 @@ impl ApmInfo {
     }
 
     pub fn set_feedback_iface(&mut self, bit: bool) -> &mut Self {
-        self.edx.contains(ApmInfoEdx::PROCFEEDBACKIF);
+        self.edx.set(ApmInfoEdx::PROCFEEDBACKIF, bit);
         self
     }
 
@@ -1271,7 +1466,7 @@ impl ApmInfo {
     }
 
     pub fn set_power_reporting_iface(&mut self, bit: bool) -> &mut Self {
-        self.edx.contains(ApmInfoEdx::PROCPWRREPORT);
+        self.edx.set(ApmInfoEdx::PROCPWRREPORT, bit);
         self
     }
 }
@@ -1393,7 +1588,7 @@ impl ProcessorCapacityAndFeatureInfo {
     }
 
     pub fn set_cl_zero(&mut self, bit: bool) -> &mut Self {
-        self.ebx.contains(ProcessorCapacityAndFeatureEbx::CLZERO);
+        self.ebx.set(ProcessorCapacityAndFeatureEbx::CLZERO, bit);
         self
     }
 
@@ -1408,7 +1603,7 @@ impl ProcessorCapacityAndFeatureInfo {
 
     pub fn set_inst_ret_cntr_msr(&mut self, bit: bool) -> &mut Self {
         self.ebx
-            .contains(ProcessorCapacityAndFeatureEbx::INST_RETCNT_MSR);
+            .set(ProcessorCapacityAndFeatureEbx::INST_RETCNT_MSR, bit);
         self
     }
 
@@ -1423,7 +1618,7 @@ impl ProcessorCapacityAndFeatureInfo {
 
     pub fn set_restore_fp_error_ptrs(&mut self, bit: bool) -> &mut Self {
         self.ebx
-            .contains(ProcessorCapacityAndFeatureEbx::RSTR_FP_ERR_PTRS);
+            .set(ProcessorCapacityAndFeatureEbx::RSTR_FP_ERR_PTRS, bit);
         self
     }
 
@@ -1436,7 +1631,7 @@ impl ProcessorCapacityAndFeatureInfo {
     }
 
     pub fn set_invlpgb(&mut self, bit: bool) -> &mut Self {
-        self.ebx.contains(ProcessorCapacityAndFeatureEbx::INVLPGB);
+        self.ebx.set(ProcessorCapacityAndFeatureEbx::INVLPGB, bit);
         self
     }
 
@@ -1449,7 +1644,7 @@ impl ProcessorCapacityAndFeatureInfo {
     }
 
     pub fn set_rdpru(&mut self, bit: bool) -> &mut Self {
-        self.ebx.contains(ProcessorCapacityAndFeatureEbx::RDPRU);
+        self.ebx.set(ProcessorCapacityAndFeatureEbx::RDPRU, bit);
         self
     }
 
@@ -1462,7 +1657,7 @@ impl ProcessorCapacityAndFeatureInfo {
     }
 
     pub fn set_mcommit(&mut self, bit: bool) -> &mut Self {
-        self.ebx.contains(ProcessorCapacityAndFeatureEbx::MCOMMIT);
+        self.ebx.set(ProcessorCapacityAndFeatureEbx::MCOMMIT, bit);
         self
     }
 
@@ -1475,7 +1670,7 @@ impl ProcessorCapacityAndFeatureInfo {
     }
 
     pub fn set_wbnoinvd(&mut self, bit: bool) -> &mut Self {
-        self.ebx.contains(ProcessorCapacityAndFeatureEbx::WBNOINVD);
+        self.ebx.set(ProcessorCapacityAndFeatureEbx::WBNOINVD, bit);
         self
     }
 
@@ -1490,7 +1685,7 @@ impl ProcessorCapacityAndFeatureInfo {
 
     pub fn set_int_wbinvd(&mut self, bit: bool) -> &mut Self {
         self.ebx
-            .contains(ProcessorCapacityAndFeatureEbx::INT_WBINVD);
+            .set(ProcessorCapacityAndFeatureEbx::INT_WBINVD, bit);
         self
     }
 
@@ -1505,7 +1700,7 @@ impl ProcessorCapacityAndFeatureInfo {
 
     pub fn set_unsupported_efer_lmsle(&mut self, bit: bool) -> &mut Self {
         self.ebx
-            .contains(ProcessorCapacityAndFeatureEbx::EFER_LMSLE_UNSUPP);
+            .set(ProcessorCapacityAndFeatureEbx::EFER_LMSLE_UNSUPP, bit);
         self
     }
 
@@ -1520,7 +1715,7 @@ impl ProcessorCapacityAndFeatureInfo {
 
     pub fn set_invlpgb_nested(&mut self, bit: bool) -> &mut Self {
         self.ebx
-            .contains(ProcessorCapacityAndFeatureEbx::INVLPGB_NESTED);
+            .set(ProcessorCapacityAndFeatureEbx::INVLPGB_NESTED, bit);
         self
     }
 
@@ -1586,7 +1781,7 @@ impl ProcessorCapacityAndFeatureInfo {
 
     /// Set the number of physical threads in the processor.
     ///
-    /// The value provided here is one more than will be recorded in the CPUID tables.
+    /// The value provided here is one more than will be recorded in the CPUID leaf.
     pub fn set_num_phys_threads(&mut self, bits: u32) -> &mut Self {
         set_bits(&mut self.ecx, bits - 1, 0, 7);
         self
@@ -2040,6 +2235,15 @@ pub struct ProcessorTopologyInfo {
 }
 
 impl ProcessorTopologyInfo {
+    pub fn empty() -> Self {
+        Self {
+            eax: 0,
+            ebx: 0,
+            ecx: 0,
+            _edx: 0,
+        }
+    }
+
     pub(crate) fn new(data: CpuIdResult) -> Self {
         Self {
             eax: data.eax,
@@ -2068,6 +2272,15 @@ impl ProcessorTopologyInfo {
     /// `Threads per Core` means `Cores per Compute Unit` if AMD Family 15h-16h Processors.
     pub fn threads_per_core(&self) -> u8 {
         get_bits(self.ebx, 8, 15) as u8 + 1
+    }
+
+    /// Set threads per core (or `Cores per Compute Unit` on AMD Family >=15h)
+    ///
+    /// # Note
+    /// The value provided here is one more than will be recorded in the CPUID leaf.
+    pub fn set_threads_per_core(&mut self, bits: u32) -> &mut Self {
+        set_bits(&mut self.ebx, bits - 1, 8, 15);
+        self
     }
 
     /// Node ID
@@ -2532,13 +2745,22 @@ impl AssignableBandwidthMonitoringCounterInfo {
 /// ✅ AMD ❌ Intel
 #[derive(PartialEq, Eq, Debug)]
 pub struct ExtendedFeatureIdentification2 {
-    eax: ExtendedFeatureIdentification2Eax,
-    ebx: u32,
-    _ecx: u32,
-    _edx: u32,
+    pub(crate) eax: ExtendedFeatureIdentification2Eax,
+    pub(crate) ebx: u32,
+    pub(crate) _ecx: u32,
+    pub(crate) _edx: u32,
 }
 
 impl ExtendedFeatureIdentification2 {
+    pub fn empty() -> Self {
+        Self {
+            eax: ExtendedFeatureIdentification2Eax::from_bits_truncate(0),
+            ebx: 0,
+            _ecx: 0,
+            _edx: 0,
+        }
+    }
+
     pub(crate) fn new(data: CpuIdResult) -> Self {
         Self {
             eax: ExtendedFeatureIdentification2Eax::from_bits_truncate(data.eax),
@@ -2554,16 +2776,36 @@ impl ExtendedFeatureIdentification2 {
             .contains(ExtendedFeatureIdentification2Eax::NO_NESTED_DATA_BP)
     }
 
+    pub fn set_no_nested_data_bp(&mut self, bit: bool) -> &mut Self {
+        self.eax
+            .set(ExtendedFeatureIdentification2Eax::NO_NESTED_DATA_BP, bit);
+        self
+    }
+
     /// LFENCE is always dispatch serializing if set
     pub fn has_lfence_always_serializing(&self) -> bool {
         self.eax
             .contains(ExtendedFeatureIdentification2Eax::LFENCE_ALWAYS_SERIALIZING)
     }
 
+    pub fn set_lfence_always_serializing(&mut self, bit: bool) -> &mut Self {
+        self.eax.set(
+            ExtendedFeatureIdentification2Eax::LFENCE_ALWAYS_SERIALIZING,
+            bit,
+        );
+        self
+    }
+
     /// SMM paging configuration lock supported if set
     pub fn has_smm_pg_cfg_lock(&self) -> bool {
         self.eax
             .contains(ExtendedFeatureIdentification2Eax::SMM_PG_CFG_LOCK)
+    }
+
+    pub fn set_smm_pg_cfg_lock(&mut self, bit: bool) -> &mut Self {
+        self.eax
+            .set(ExtendedFeatureIdentification2Eax::SMM_PG_CFG_LOCK, bit);
+        self
     }
 
     /// Null segment selector loads also clear the destination segment register
@@ -2573,10 +2815,24 @@ impl ExtendedFeatureIdentification2 {
             .contains(ExtendedFeatureIdentification2Eax::NULL_SELECT_CLEARS_BASE)
     }
 
+    pub fn set_null_select_clears_base(&mut self, bit: bool) -> &mut Self {
+        self.eax.set(
+            ExtendedFeatureIdentification2Eax::NULL_SELECT_CLEARS_BASE,
+            bit,
+        );
+        self
+    }
+
     /// Upper Address Ignore is supported if set
     pub fn has_upper_address_ignore(&self) -> bool {
         self.eax
             .contains(ExtendedFeatureIdentification2Eax::UPPER_ADDRESS_IGNORE)
+    }
+
+    pub fn set_upper_address_ignore(&mut self, bit: bool) -> &mut Self {
+        self.eax
+            .set(ExtendedFeatureIdentification2Eax::UPPER_ADDRESS_IGNORE, bit);
+        self
     }
 
     /// Automatic IBRS if set
@@ -2585,10 +2841,22 @@ impl ExtendedFeatureIdentification2 {
             .contains(ExtendedFeatureIdentification2Eax::AUTOMATIC_IBRS)
     }
 
+    pub fn set_automatic_ibrs(&mut self, bit: bool) -> &mut Self {
+        self.eax
+            .set(ExtendedFeatureIdentification2Eax::AUTOMATIC_IBRS, bit);
+        self
+    }
+
     /// SMM_CTL MSR (C001_0116h) is not supported if set
     pub fn has_no_smm_ctl_msr(&self) -> bool {
         self.eax
             .contains(ExtendedFeatureIdentification2Eax::NO_SMM_CTL_MSR)
+    }
+
+    pub fn set_no_smm_ctl_msr(&mut self, bit: bool) -> &mut Self {
+        self.eax
+            .set(ExtendedFeatureIdentification2Eax::NO_SMM_CTL_MSR, bit);
+        self
     }
 
     /// Prefetch control MSR supported if set
@@ -2597,10 +2865,22 @@ impl ExtendedFeatureIdentification2 {
             .contains(ExtendedFeatureIdentification2Eax::PREFETCH_CTL_MSR)
     }
 
+    pub fn set_prefetch_ctl_msr(&mut self, bit: bool) -> &mut Self {
+        self.eax
+            .set(ExtendedFeatureIdentification2Eax::PREFETCH_CTL_MSR, bit);
+        self
+    }
+
     /// CPUID disable for non-privileged software if set
     pub fn has_cpuid_user_dis(&self) -> bool {
         self.eax
             .contains(ExtendedFeatureIdentification2Eax::CPUID_USER_DIS)
+    }
+
+    pub fn set_cpuid_user_dis(&mut self, bit: bool) -> &mut Self {
+        self.eax
+            .set(ExtendedFeatureIdentification2Eax::CPUID_USER_DIS, bit);
+        self
     }
 
     /// The size of the Microcode patch in 16-byte multiples. If 0, the size of the
@@ -2608,12 +2888,17 @@ impl ExtendedFeatureIdentification2 {
     pub fn microcode_patch_size(&self) -> u16 {
         get_bits(self.ebx, 0, 11) as u16
     }
+
+    pub fn microcode_patcset_size(&mut self, bits: u32) -> &mut Self {
+        set_bits(&mut self.ebx, bits, 0, 11);
+        self
+    }
 }
 
 bitflags! {
     #[repr(transparent)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    struct ExtendedFeatureIdentification2Eax: u32 {
+    pub(crate) struct ExtendedFeatureIdentification2Eax: u32 {
         const NO_NESTED_DATA_BP = 1 << 0;
         const LFENCE_ALWAYS_SERIALIZING = 1 << 2;
         const SMM_PG_CFG_LOCK = 1 << 3;

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -426,7 +426,7 @@ bitflags! {
         const SYSCALL_SYSRET = 1 << 11;
         const EXECUTE_DISABLE = 1 << 20;
         const MMXEXT = 1 << 22;
-        const FFXSR = 1 << 24;
+        const FFXSR = 1 << 25;
         const GIB_PAGES = 1 << 26;
         const RDTSCP = 1 << 27;
         const I64BIT_MODE = 1 << 29;

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -1293,8 +1293,8 @@ impl ApmInfo {
         self.ecx
     }
 
-    pub fn set_pwr_sample_time_ratio(&mut self, bit: bool) -> &mut Self {
-        self.ecx;
+    pub fn set_pwr_sample_time_ratio(&mut self, bits: u32) -> &mut Self {
+        self.ecx = bits;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,9 @@ extern crate std;
 
 #[cfg(feature = "display")]
 pub mod display;
-mod extended;
 #[cfg(feature = "std")]
 mod dump;
+mod extended;
 #[cfg(test)]
 mod tests;
 
@@ -69,9 +69,9 @@ use core::str;
 #[cfg(feature = "serialize")]
 use serde_derive::{Deserialize, Serialize};
 
-pub use extended::*;
 #[cfg(feature = "std")]
 pub use dump::CpuIdDump;
+pub use extended::*;
 
 /// Uses Rust's `cpuid` function from the `arch` module.
 #[cfg(any(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@ extern crate std;
 #[cfg(feature = "display")]
 pub mod display;
 mod extended;
+#[cfg(feature = "std")]
+mod dump;
 #[cfg(test)]
 mod tests;
 
@@ -68,6 +70,8 @@ use core::str;
 use serde_derive::{Deserialize, Serialize};
 
 pub use extended::*;
+#[cfg(feature = "std")]
+pub use dump::CpuIdDump;
 
 /// Uses Rust's `cpuid` function from the `arch` module.
 #[cfg(any(
@@ -502,7 +506,7 @@ impl<W: CpuIdReader + CpuIdWriter> CpuId<W> {
      * set_soc_vendor_info (leaf 17h)
      * set_deterministic_address_translation_info (leaf 18h)
      * set_hypervisor_info
-    */
+     */
 
     /// Set information about how monitor/mwait works on this CPU (LEAF=0x05).
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3730,6 +3730,15 @@ pub struct MonitorMwaitInfo {
 }
 
 impl MonitorMwaitInfo {
+    pub fn empty() -> Self {
+        Self {
+            eax: 0,
+            ebx: 0,
+            ecx: 0,
+            edx: 0,
+        }
+    }
+
     /// Smallest monitor-line size in bytes (default is processor's monitor granularity)
     ///
     /// # Platforms

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -889,7 +889,7 @@ impl<R: CpuIdReader> CpuId<R> {
         }
     }
 
-    /// This function provides information about the SVM features that the processory
+    /// This function provides information about the SVM features that the processor
     /// supports. (LEAF=0x8000_000A)
     ///
     /// If SVM is not supported if [ExtendedProcessorFeatureIdentifiers::has_svm] is
@@ -2810,7 +2810,7 @@ impl MonitorMwaitInfo {
         get_bits(self.eax, 0, 15) as u16
     }
 
-    /// Largest monitor-line size in bytes (default is processor's monitor granularity
+    /// Largest monitor-line size in bytes (default is processor's monitor granularity)
     ///
     /// # Platforms
     /// ✅ AMD ✅ Intel
@@ -3710,6 +3710,15 @@ impl ExtendedFeatures {
         self.edx.contains(ExtendedFeaturesEdx::AVX512_4FMAPS)
     }
 
+    /// Supports FSRM.
+    ///
+    /// # Platforms
+    /// ✅ AMD ✅ Intel
+    #[inline]
+    pub const fn has_fsrm(&self) -> bool {
+        self.edx.contains(ExtendedFeaturesEdx::FSRM)
+    }
+
     /// Supports AVX512_VP2INTERSECT.
     ///
     /// # Platforms
@@ -3952,7 +3961,7 @@ bitflags! {
         const RDTM = 1 << 12;
         /// Deprecates FPU CS and FPU DS values if 1. (Bit 13)
         const DEPRECATE_FPU_CS_DS = 1 << 13;
-        /// Deprecates FPU CS and FPU DS values if 1. (Bit 14)
+        /// Supports Intel Memory Protection Extensions if set. (Bit 14)
         const MPX = 1 << 14;
         /// Supports Intel Resource Director Technology (RDT) Allocation capability if 1.
         const RDTA = 1 << 15;
@@ -4053,6 +4062,9 @@ bitflags! {
         const AVX512_4VNNIW = 1 << 2;
         /// Bit 03: AVX512_4FMAPS. (Intel® Xeon Phi™ only).
         const AVX512_4FMAPS = 1 << 3;
+        /// Bit 04: Fast Short REP MOVSB (FSRM). Documented only in Intel SDM, present on Intel and
+        /// AMD (Zen 3 and later).
+        const FSRM = 1 << 4;
         /// Bit 08: AVX512_VP2INTERSECT.
         const AVX512_VP2INTERSECT = 1 << 8;
         /// Bit 22: AMX-BF16. If 1, the processor supports tile computational operations on bfloat16 numbers.
@@ -4063,6 +4075,8 @@ bitflags! {
         const AMX_TILE = 1 << 24;
         /// Bit 25: AMX-INT8. If 1, the processor supports tile computational operations on 8-bit integers.
         const AMX_INT8 = 1 << 25;
+        /// Bit 26: IBRS and IBPB. If 1, the processor supports Indirect Branch Restricted Speculation and Indirect Branch Prediction Barrier controls.
+        const IBRS = 1 << 26;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6215,7 +6215,7 @@ impl<F: CpuIdReader> ExtendedStateInfo<F> {
     }
 
     pub fn set_xsaveopt(&mut self, bit: bool) -> &mut Self {
-        self.eax1 & !(1 << 0);
+        self.eax1 &= !(1 << 0);
         self.eax1 |= bit as u32;
         self
     }
@@ -6226,7 +6226,7 @@ impl<F: CpuIdReader> ExtendedStateInfo<F> {
     }
 
     pub fn set_xsavec(&mut self, bit: bool) -> &mut Self {
-        self.eax1 & !(1 << 1);
+        self.eax1 &= !(1 << 1);
         self.eax1 |= (bit as u32) << 1;
         self
     }
@@ -6237,7 +6237,7 @@ impl<F: CpuIdReader> ExtendedStateInfo<F> {
     }
 
     pub fn set_xgetbv(&mut self, bit: bool) -> &mut Self {
-        self.eax1 & !(1 << 2);
+        self.eax1 &= !(1 << 2);
         self.eax1 |= (bit as u32) << 2;
         self
     }
@@ -6248,7 +6248,7 @@ impl<F: CpuIdReader> ExtendedStateInfo<F> {
     }
 
     pub fn set_xsavex_xrstors(&mut self, bit: bool) -> &mut Self {
-        self.eax1 & !(1 << 3);
+        self.eax1 &= !(1 << 3);
         self.eax1 |= (bit as u32) << 3;
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -976,12 +976,6 @@ impl<W: CpuIdReader + CpuIdWriter> CpuId<W> {
                     .expect("extended cache parameters subleaf fits into u32");
                 self.source
                     .set_subleaf(EAX_CACHE_PARAMETERS_AMD, idx, Some(*level));
-                /* CpuIdResult {
-                    eax: level.eax,
-                    ebx: level.ebx,
-                    ecx: level.ecx,
-                    edx: level.edx,
-                })); */
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,6 +389,11 @@ const EAX_CACHE_PARAMETERS_AMD: u32 = 0x8000_001D;
 const EAX_PROCESSOR_TOPOLOGY_INFO: u32 = 0x8000_001E;
 const EAX_MEMORY_ENCRYPTION_INFO: u32 = 0x8000_001F;
 const EAX_SVM_FEATURES: u32 = 0x8000_000A;
+const EAX_PQOS_EXTENDED_FEATURES: u32 = 0x8000_0020;
+const EAX_EXTENDED_FEATURE_IDENTIFICATION_2: u32 = 0x8000_0021;
+const EAX_EXTENDED_PERFORMANCE_MONITORING_AND_DEBUG: u32 = 0x8000_0022;
+const EAX_MULTI_KEY_ENCRYPTED_MEMORY_CAPABILITIES: u32 = 0x8000_0023;
+const EAX_EXTENDED_CPU_TOPOLOGY: u32 = 0x8000_0026;
 
 // TODO: Would be nice to not require CpuIdReader here, as we don't use it, but:
 // * `struct CpuId` requires `source`: implements `CpuIdReader`
@@ -1774,6 +1779,78 @@ impl<R: CpuIdReader> CpuId<R> {
             Some(MemoryEncryptionInfo::new(
                 self.source.cpuid1(EAX_MEMORY_ENCRYPTION_INFO),
             ))
+        } else {
+            None
+        }
+    }
+
+    /// Informations about Platform Quality of Service (LEAF=0x8000_0020)
+    ///
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved)
+    pub fn get_pqos_extended_feature_info(&self) -> Option<PqosExtendedFeatureInfo<R>> {
+        if self.leaf_is_supported(EAX_PQOS_EXTENDED_FEATURES) {
+            Some(PqosExtendedFeatureInfo::new(self.source.clone()))
+        } else {
+            None
+        }
+    }
+
+    /// Extended Feature Identification 2 (LEAF=0x8000_0021)
+    ///
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved)
+    pub fn get_extended_feature_identification_2(&self) -> Option<ExtendedFeatureIdentification2> {
+        if self.leaf_is_supported(EAX_EXTENDED_FEATURE_IDENTIFICATION_2) {
+            Some(ExtendedFeatureIdentification2::new(
+                self.source.cpuid1(EAX_EXTENDED_FEATURE_IDENTIFICATION_2),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Extended Performance Monitoring and Debug (LEAF=0x8000_0022)
+    ///
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved)
+    pub fn get_extended_performance_monitoring_and_debug(
+        &self,
+    ) -> Option<ExtendedPerformanceMonitoringDebug> {
+        if self.leaf_is_supported(EAX_EXTENDED_PERFORMANCE_MONITORING_AND_DEBUG) {
+            Some(ExtendedPerformanceMonitoringDebug::new(
+                self.source
+                    .cpuid1(EAX_EXTENDED_PERFORMANCE_MONITORING_AND_DEBUG),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Multi-Key Encrypted Memory Capabilities (LEAF=0x8000_0023)
+    ///
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved)
+    pub fn get_multi_key_encrypted_memory_capabilities(
+        &self,
+    ) -> Option<MultiKeyEncryptedMemoryCapabilities> {
+        if self.leaf_is_supported(EAX_MULTI_KEY_ENCRYPTED_MEMORY_CAPABILITIES) {
+            Some(MultiKeyEncryptedMemoryCapabilities::new(
+                self.source
+                    .cpuid1(EAX_MULTI_KEY_ENCRYPTED_MEMORY_CAPABILITIES),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Extended CPU Topolog (LEAF=0x8000_0026)
+    ///
+    /// # Platforms
+    /// ✅ AMD ❌ Intel (reserved)
+    pub fn get_extended_cpu_topology(&self) -> Option<ExtendedCpuTopologyIter<R>> {
+        if self.leaf_is_supported(EAX_EXTENDED_CPU_TOPOLOGY) {
+            Some(ExtendedCpuTopologyIter::new(self.source.clone()))
         } else {
             None
         }

--- a/src/tests/i5_3337u.rs
+++ b/src/tests/i5_3337u.rs
@@ -433,7 +433,7 @@ fn extended_topology_info_v2() {
 #[test]
 fn extended_state_info() {
     let es = ExtendedStateInfo {
-        read: CpuIdReaderNative,
+        source: CpuIdReaderNative,
         eax: ExtendedStateInfoXCR0Flags::from_bits_truncate(7),
         ebx: 832,
         ecx: 832,
@@ -460,7 +460,7 @@ fn extended_state_info3() {
     });*/
 
     let esi = ExtendedStateInfo {
-        read: CpuIdReaderNative,
+        source: CpuIdReaderNative,
         eax: ExtendedStateInfoXCR0Flags::LEGACY_X87
             | ExtendedStateInfoXCR0Flags::SSE128
             | ExtendedStateInfoXCR0Flags::AVX256
@@ -619,7 +619,7 @@ fn extended_state_info3() {
 #[test]
 fn extended_state_info2() {
     let es = ExtendedStateInfo {
-        read: CpuIdReaderNative,
+        source: CpuIdReaderNative,
         eax: ExtendedStateInfoXCR0Flags::from_bits_truncate(31),
         ebx: 1088,
         ecx: 1088,
@@ -694,7 +694,7 @@ fn extended_state_info2() {
 #[test]
 fn quality_of_service_info() {
     let qos = RdtMonitoringInfo {
-        read: CpuIdReaderNative,
+        source: CpuIdReaderNative,
         ebx: 832,
         edx: 0,
     };
@@ -755,7 +755,7 @@ fn processor_brand_string() {
 #[test]
 fn sgx_test() {
     let sgx = SgxInfo {
-        read: CpuIdReaderNative,
+        source: CpuIdReaderNative,
         eax: 1,
         ebx: 0,
         _ecx: 0,

--- a/src/tests/ryzen_matisse.rs
+++ b/src/tests/ryzen_matisse.rs
@@ -1268,4 +1268,34 @@ fn remaining_unsupported_leafs() {
     assert!(cpuid.get_deterministic_address_translation_info().is_none());
     assert!(cpuid.get_soc_vendor_info().is_none());
     assert!(cpuid.get_extended_topology_info_v2().is_none());
+    assert!(cpuid.get_extended_feature_identification_2().is_none());
+    assert!(cpuid
+        .get_extended_performance_monitoring_and_debug()
+        .is_none());
+    assert!(cpuid
+        .get_multi_key_encrypted_memory_capabilities()
+        .is_none());
+    assert!(cpuid.get_extended_cpu_topology().is_none());
+}
+
+#[test]
+fn platform_quality_service() {
+    let cpuid = CpuId::with_cpuid_fn(cpuid_reader);
+    let e = cpuid
+        .get_pqos_extended_feature_info()
+        .expect("Leaf is supported");
+
+    assert!(e.has_l3mbe());
+    assert!(!e.has_l3smbe());
+    assert!(!e.has_abmc());
+    assert!(!e.has_bmec());
+    assert!(!e.has_l3rr());
+    assert!(!e.has_sdciae());
+
+    let f = e
+        .get_l3_memory_bandwidth_enforcement_info()
+        .expect("SubLeaf is supported");
+
+    assert!(f.bandwidth_length() == 0x0000_000b);
+    assert!(f.cos_max() == 0x0000_000f);
 }


### PR DESCRIPTION
hi! In https://github.com/oxidecomputer/omicron/pull/8728 I've wanted to assemble synthetic CPUID profiles; an initial run at that involved a fairly impenetrable array of 33 leaves/subleaves. It's _much_ better to be able to write out all the bits and get a table out, so this patch takes a swing at doing that. We're using this in our fork, but it seems useful enough I wonder if you might want this in `rust-cpuid` itself?

If you're in favor of pulling this in, I'll pick #205, #204, and #202 back out of this PR and clean up the history some. Even so, this is a draft because there are a few wrinkles here that need sorting out - I'll leave comments here about what stands out to me.

I've included an approximation of the CPUID profile I'm assembling there as an `examples/synthetic.rs` here to live as a demonstration of using the new APIs. I was also pleasantly surprised that this lets you write reasonable tests like "this CPUID profile should be different from that profile only in these ways", or "these CPUID profiles are wholly incompatible if they vary on these fields" (such as for CPUID fields that describe architectural behavior, like the XSAVE region layout - it'd be quite bad to run a VM that wants one XSAVE layout on a processor that does another...)