### PR TITLE
gate stuff so that cargo build works on non-x86

### DIFF
--- a/src/bin/cpuid.rs
+++ b/src/bin/cpuid.rs
@@ -4,6 +4,7 @@
 use std::str::FromStr;
 
 use clap::{Parser, ValueEnum};
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 use raw_cpuid::{CpuId, CpuIdReaderNative};
 
 #[derive(ValueEnum, Clone)]
@@ -36,6 +37,7 @@ struct Opts {
     format: OutputFormat,
 }
 
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 fn main() {
     let opts: Opts = Opts::parse();
     match opts.format {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 //!
 //! ## Example
 //! ```rust
+//! #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+//! {
 //! use raw_cpuid::CpuId;
 //! let cpuid = CpuId::new();
 //!
@@ -23,6 +25,7 @@
 //!     }
 //! } else {
 //!     println!("No cache parameter information available")
+//! }
 //! }
 //! ```
 //!
@@ -6031,6 +6034,7 @@ impl<R: CpuIdReader> HypervisorInfo<R> {
 }
 
 #[cfg(doctest)]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 mod test_readme {
     macro_rules! external_doc_test {
         ($x:expr) => {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod xeon_gold_6252;
 use crate::*;
 
 #[test]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 fn cpuid_impls_debug() {
     fn debug_required<T: Debug>(_t: T) {}
 


### PR DESCRIPTION
Based on https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/raw-cpuid/debian/patches/build-on-non-x86.patch#L859